### PR TITLE
PTOW-2: Update the pubx analytics adapter. 

### DIFF
--- a/modules/pubxaiAnalyticsAdapter.js
+++ b/modules/pubxaiAnalyticsAdapter.js
@@ -4,24 +4,40 @@ import {
   getWindowLocation,
   buildUrl,
   cyrb53Hash,
-} from '../src/utils.js';
-import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
-import adapterManager from '../src/adapterManager.js';
-import CONSTANTS from '../src/constants.json';
-import { getGlobal } from '../src/prebidGlobal.js';
+} from "../src/utils.js";
+import adapter from "../libraries/analyticsAdapter/AnalyticsAdapter.js";
+import adapterManager from "../src/adapterManager.js";
+import CONSTANTS from "../src/constants.json";
+import { getGlobal } from "../src/prebidGlobal.js";
 import {
   getGptSlotInfoForAdUnitCode,
   getGptSlotForAdUnitCode,
-} from '../libraries/gptUtils/gptUtils.js';
+} from "../libraries/gptUtils/gptUtils.js";
 
 let initOptions;
 
-const emptyUrl = '';
-const analyticsType = 'endpoint';
-const pubxaiAnalyticsVersion = 'v1.2.0';
-const defaultHost = 'api.pbxai.com';
-const auctionPath = '/analytics/auction';
-const winningBidPath = '/analytics/bidwon';
+const emptyUrl = "";
+const analyticsType = "endpoint";
+const pubxaiAnalyticsVersion = "v1.2.0";
+const defaultHost = "api.pbxai.com";
+const auctionPath = "/analytics/auction";
+const winningBidPath = "/analytics/bidwon";
+
+/**
+ * The sendCache is a global cache object which tracks the pending sends
+ * back to pubx.ai. The data may be removed from this cache, post send.
+ */
+export const sendCache = new Proxy(
+  {},
+  {
+    get: (target, name) => {
+      if (!Object.hasOwn(target, name)) {
+        target[name] = [];
+      }
+      return target[name];
+    },
+  }
+);
 
 /**
  * auctionCache is a global cache object which stores all auction histories
@@ -59,18 +75,29 @@ export const auctionCache = new Proxy(
           consentDetail: {
             consentTypes: Object.keys(getGlobal().getConsentMetadata?.() || {}),
           },
-          pmacDetail: JSON.parse(getStorage()?.getItem('pubx:pmac')) || {}, // {auction_1: {floor:0.23,maxBid:0.34,bidCount:3},auction_2:{floor:0.13,maxBid:0.14,bidCount:2}
+          pmacDetail: JSON.parse(getStorage()?.getItem("pubx:pmac")) || {}, // {auction_1: {floor:0.23,maxBid:0.34,bidCount:3},auction_2:{floor:0.13,maxBid:0.14,bidCount:2}
           initOptions: {
             ...initOptions,
             auctionId: name, // back-compat
           },
-          sentAs: [],
+          sendAs: [],
         };
       }
       return target[name];
     },
   }
 );
+
+/**
+ *
+ * @returns {boolean} whether or not the browser session supports sendBeacon
+ */
+const hasSendBeaconSupport = () => {
+  if (!navigator.sendBeacon || !document.visibilityState) {
+    return false;
+  }
+  return true;
+};
 
 /**
  * Fetch extra ad server data for a specific ad slot (bid)
@@ -85,8 +112,8 @@ const getAdServerDataForBid = (bid) => {
         .getTargetingKeys()
         .filter(
           (key) =>
-            key.startsWith('pubx-') ||
-            (key.startsWith('hb_') && (key.match(/_/g) || []).length === 1)
+            key.startsWith("pubx-") ||
+            (key.startsWith("hb_") && (key.match(/_/g) || []).length === 1)
         )
         .map((key) => [key, gptSlot.getTargeting(key)])
     );
@@ -100,7 +127,7 @@ const getAdServerDataForBid = (bid) => {
  */
 const getStorage = () => {
   try {
-    return window.top['sessionStorage'];
+    return window.top["sessionStorage"];
   } catch (e) {
     return null;
   }
@@ -135,7 +162,7 @@ const extractBid = (bidResponse) => {
     transactionId: bidResponse.transactionId,
     bidId: bidResponse.bidId || bidResponse.requestId,
     placementId: bidResponse.params
-      ? deepAccess(bidResponse, 'params.0.placementId')
+      ? deepAccess(bidResponse, "params.0.placementId")
       : null,
   };
 };
@@ -179,7 +206,7 @@ const track = ({ eventType, args }) => {
       if (
         auctionCache[args.auctionId].bids.every((bid) => bid.renderStatus === 3)
       ) {
-        send(args.auctionId);
+        prepareSend(args.auctionId);
       }
       break;
     // send the prebid winning bid back to pubx
@@ -199,7 +226,7 @@ const track = ({ eventType, args }) => {
       });
       winningBid.adServerData = getAdServerDataForBid(winningBid);
       auctionCache[winningBid.auctionId].winningBid = winningBid;
-      send(winningBid.auctionId);
+      prepareSend(winningBid.auctionId);
       break;
     // do nothing
     default:
@@ -217,16 +244,16 @@ export const getDeviceType = () => {
       navigator.userAgent.toLowerCase()
     )
   ) {
-    return 'tablet';
+    return "tablet";
   }
   if (
     /iphone|ipod|android|blackberry|opera|mini|windows\sce|palm|smartphone|iemobile/i.test(
       navigator.userAgent.toLowerCase()
     )
   ) {
-    return 'mobile';
+    return "mobile";
   }
-  return 'desktop';
+  return "desktop";
 };
 
 /**
@@ -238,21 +265,21 @@ export const getBrowser = () => {
     /Chrome/.test(navigator.userAgent) &&
     /Google Inc/.test(navigator.vendor)
   ) {
-    return 'Chrome';
-  } else if (navigator.userAgent.match('CriOS')) return 'Chrome';
-  else if (/Firefox/.test(navigator.userAgent)) return 'Firefox';
-  else if (/Edg/.test(navigator.userAgent)) return 'Microsoft Edge';
+    return "Chrome";
+  } else if (navigator.userAgent.match("CriOS")) return "Chrome";
+  else if (/Firefox/.test(navigator.userAgent)) return "Firefox";
+  else if (/Edg/.test(navigator.userAgent)) return "Microsoft Edge";
   else if (
     /Safari/.test(navigator.userAgent) &&
     /Apple Computer/.test(navigator.vendor)
   ) {
-    return 'Safari';
+    return "Safari";
   } else if (
     /Trident/.test(navigator.userAgent) ||
     /MSIE/.test(navigator.userAgent)
   ) {
-    return 'Internet Explorer';
-  } else return 'Others';
+    return "Internet Explorer";
+  } else return "Others";
 };
 
 /**
@@ -260,13 +287,13 @@ export const getBrowser = () => {
  * @returns {string}
  */
 export const getOS = () => {
-  if (navigator.userAgent.indexOf('Android') != -1) return 'Android';
-  if (navigator.userAgent.indexOf('like Mac') != -1) return 'iOS';
-  if (navigator.userAgent.indexOf('Win') != -1) return 'Windows';
-  if (navigator.userAgent.indexOf('Mac') != -1) return 'Macintosh';
-  if (navigator.userAgent.indexOf('Linux') != -1) return 'Linux';
-  if (navigator.appVersion.indexOf('X11') != -1) return 'Unix';
-  return 'Others';
+  if (navigator.userAgent.indexOf("Android") != -1) return "Android";
+  if (navigator.userAgent.indexOf("like Mac") != -1) return "iOS";
+  if (navigator.userAgent.indexOf("Win") != -1) return "Windows";
+  if (navigator.userAgent.indexOf("Mac") != -1) return "Macintosh";
+  if (navigator.userAgent.indexOf("Linux") != -1) return "Linux";
+  if (navigator.appVersion.indexOf("X11") != -1) return "Unix";
+  return "Others";
 };
 
 /**
@@ -280,10 +307,10 @@ const shouldFireEventRequest = (auctionId, samplingRate = 1) => {
 };
 
 /**
- * Send auction data back to pubx.ai
+ * prepare the payload for sending auction data back to pubx.ai
  * @param {string} auctionId the auction to send
  */
-const send = (auctionId) => {
+const prepareSend = (auctionId) => {
   const auctionData = Object.assign({}, auctionCache[auctionId]);
   if (!shouldFireEventRequest(auctionId, initOptions.samplingRate)) {
     return;
@@ -292,45 +319,45 @@ const send = (auctionId) => {
     {
       path: winningBidPath,
       requiredKeys: [
-        'winningBid',
-        'pageDetail',
-        'deviceDetail',
-        'floorDetail',
-        'auctionDetail',
-        'userDetail',
-        'consentDetail',
-        'pmacDetail',
-        'initOptions',
+        "winningBid",
+        "pageDetail",
+        "deviceDetail",
+        "floorDetail",
+        "auctionDetail",
+        "userDetail",
+        "consentDetail",
+        "pmacDetail",
+        "initOptions",
       ],
-      eventType: 'win',
+      eventType: "win",
     },
     {
       path: auctionPath,
       requiredKeys: [
-        'bids',
-        'pageDetail',
-        'deviceDetail',
-        'floorDetail',
-        'auctionDetail',
-        'userDetail',
-        'consentDetail',
-        'pmacDetail',
-        'initOptions',
+        "bids",
+        "pageDetail",
+        "deviceDetail",
+        "floorDetail",
+        "auctionDetail",
+        "userDetail",
+        "consentDetail",
+        "pmacDetail",
+        "initOptions",
       ],
-      eventType: 'auction',
+      eventType: "auction",
     },
   ].forEach(({ path, requiredKeys, eventType }) => {
     const data = Object.fromEntries(
       requiredKeys.map((key) => [key, auctionData[key]])
     );
     if (
-      auctionCache[auctionId].sentAs.includes(eventType) ||
+      auctionCache[auctionId].sendAs.includes(eventType) ||
       !requiredKeys.every((key) => !!auctionData[key])
     ) {
       return;
     }
     const pubxaiAnalyticsRequestUrl = buildUrl({
-      protocol: 'https',
+      protocol: "https",
       hostname:
         (auctionData.initOptions && auctionData.initOptions.hostName) ||
         defaultHost,
@@ -341,14 +368,44 @@ const send = (auctionId) => {
         prebidVersion: getGlobal().version,
       },
     });
-    const payload = new Blob([JSON.stringify(data)], {
-      type: 'text/json',
-    });
-    navigator.sendBeacon(pubxaiAnalyticsRequestUrl, payload);
-    auctionCache[auctionId].sentAs.push(eventType);
+    sendCache[pubxaiAnalyticsRequestUrl].push(data);
+    auctionCache[auctionId].sendAs.push(eventType);
   });
 };
 
+const send = () => {
+  const toBlob = (d) => new Blob([JSON.stringify(d)], { type: "text/json" });
+
+  Object.entries(sendCache).forEach(([requestUrl, events]) => {
+    let payloadStart = 0;
+
+    events.forEach((event, index, arr) => {
+      const payload = arr.slice(payloadStart, index + 2);
+      const payloadTooLarge = toBlob(payload).size > 65536;
+
+      if (payloadTooLarge || index + 1 === arr.length) {
+        navigator.sendBeacon(
+          requestUrl,
+          toBlob(payloadTooLarge ? payload.slice(0, -1) : payload)
+        );
+        payloadStart = index;
+      }
+    });
+
+    events.splice(0);
+  });
+};
+
+// register event listener to send logs when user leaves page
+if (hasSendBeaconSupport()) {
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") {
+      send();
+    }
+  });
+}
+
+// declare the analytics adapter
 var pubxaiAnalyticsAdapter = Object.assign(
   adapter({
     emptyUrl,
@@ -356,7 +413,6 @@ var pubxaiAnalyticsAdapter = Object.assign(
   }),
   { track }
 );
-pubxaiAnalyticsAdapter.track = track;
 
 pubxaiAnalyticsAdapter.originEnableAnalytics =
   pubxaiAnalyticsAdapter.enableAnalytics;
@@ -367,7 +423,7 @@ pubxaiAnalyticsAdapter.enableAnalytics = (config) => {
 
 adapterManager.registerAnalyticsAdapter({
   adapter: pubxaiAnalyticsAdapter,
-  code: 'pubxai',
+  code: "pubxai",
 });
 
 export default pubxaiAnalyticsAdapter;

--- a/modules/pubxaiAnalyticsAdapter.js
+++ b/modules/pubxaiAnalyticsAdapter.js
@@ -18,7 +18,7 @@ let initOptions;
 
 const emptyUrl = "";
 const analyticsType = "endpoint";
-const pubxaiAnalyticsVersion = "v1.2.0";
+const pubxaiAnalyticsVersion = "v2.0.0";
 const defaultHost = "api.pbxai.com";
 const auctionPath = "/analytics/auction";
 const winningBidPath = "/analytics/bidwon";
@@ -261,25 +261,25 @@ export const getDeviceType = () => {
  * @returns {string}
  */
 export const getBrowser = () => {
-  if (
+  if (/Edg/.test(navigator.userAgent)) return "Microsoft Edge";
+  else if (
     /Chrome/.test(navigator.userAgent) &&
     /Google Inc/.test(navigator.vendor)
-  ) {
+  )
     return "Chrome";
-  } else if (navigator.userAgent.match("CriOS")) return "Chrome";
+  else if (navigator.userAgent.match("CriOS")) return "Chrome";
   else if (/Firefox/.test(navigator.userAgent)) return "Firefox";
-  else if (/Edg/.test(navigator.userAgent)) return "Microsoft Edge";
   else if (
     /Safari/.test(navigator.userAgent) &&
     /Apple Computer/.test(navigator.vendor)
-  ) {
+  )
     return "Safari";
-  } else if (
+  else if (
     /Trident/.test(navigator.userAgent) ||
     /MSIE/.test(navigator.userAgent)
-  ) {
+  )
     return "Internet Explorer";
-  } else return "Others";
+  else return "Others";
 };
 
 /**

--- a/test/spec/modules/pubxaiAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubxaiAnalyticsAdapter_spec.js
@@ -692,17 +692,23 @@ describe('pubxai analytics adapter', () => {
     });
 
     beforeEach(() => {
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'hidden',
+        writable: true,
+      }); // prep for the document visibility state change
       adapterManager.enableAnalytics({
         provider: 'pubxai',
         options: initOptions,
       });
       sinon.stub(navigator, 'sendBeacon').returns(true);
+      sinon.stub();
     });
 
     afterEach(() => {
       pubxaiAnalyticsAdapter.disableAnalytics();
       navigator.sendBeacon.restore();
       delete auctionCache['bc3806e4-873e-453c-8ae5-204f35e923b4'];
+      delete auctionCache['auction2'];
     });
 
     it('builds and sends auction data', async () => {
@@ -721,10 +727,16 @@ describe('pubxai analytics adapter', () => {
       // Step 5: Send auction end event
       events.emit(constants.EVENTS.AUCTION_END, prebidEvent['auctionEnd']);
 
+      // Simulate "navigate away" behaviour
+      document.dispatchEvent(new Event('visibilitychange'));
+
       expect(navigator.sendBeacon.callCount).to.equal(0);
 
       // Step 6: Send auction bid won event
       events.emit(constants.EVENTS.BID_WON, prebidEvent['bidWon']);
+
+      // Simulate end of session
+      document.dispatchEvent(new Event('visibilitychange'));
 
       expect(navigator.sendBeacon.callCount).to.equal(2);
 
@@ -740,9 +752,9 @@ describe('pubxai analytics adapter', () => {
           prebidVersion: 'undefined', // not configured for test case
         });
         expect(expectedData.type).to.equal('text/json');
-        expect(JSON.parse(await expectedData.text())).to.deep.equal(
-          [expectedAfterBidWon, expectedAfterBid][index]
-        );
+        expect(JSON.parse(await expectedData.text())).to.deep.equal([
+          [expectedAfterBidWon, expectedAfterBid][index],
+        ]);
       }
     });
 
@@ -756,11 +768,17 @@ describe('pubxai analytics adapter', () => {
       // Step 3: Send bid time out event
       events.emit(constants.EVENTS.BID_TIMEOUT, prebidEvent['bidTimeout']);
 
+      // Simulate "navigate away" behaviour
+      document.dispatchEvent(new Event('visibilitychange'));
+
       // Step 4: check the number of calls made to pubx.ai
       expect(navigator.sendBeacon.callCount).to.equal(0);
 
       // Step 5: Send auction end event
       events.emit(constants.EVENTS.AUCTION_END, prebidEvent['auctionEnd']);
+
+      // Simulate end of session
+      document.dispatchEvent(new Event('visibilitychange'));
 
       // Step 6: check the number of calls made to pubx.ai
       expect(navigator.sendBeacon.callCount).to.equal(1);
@@ -779,10 +797,12 @@ describe('pubxai analytics adapter', () => {
 
       // Step 9: check that the data sent in the request is correct
       expect(expectedData.type).to.equal('text/json');
-      expect(JSON.parse(await expectedData.text())).to.deep.equal({
-        ...expectedAfterBid,
-        bids: [],
-      });
+      expect(JSON.parse(await expectedData.text())).to.deep.equal([
+        {
+          ...expectedAfterBid,
+          bids: [],
+        },
+      ]);
     });
 
     it('2 concurrent auctions', async () => {
@@ -837,11 +857,17 @@ describe('pubxai analytics adapter', () => {
       // Step 8: Send auction end event for auction 1
       events.emit(constants.EVENTS.AUCTION_END, prebidEvent['auctionEnd']);
 
+      // Simulate "navigate away" behaviour
+      document.dispatchEvent(new Event('visibilitychange'));
+
       // Step 9: check the number of calls made to pubx.ai
       expect(navigator.sendBeacon.callCount).to.equal(0);
 
       // Step 10: Send auction bid won event for auction 1
       events.emit(constants.EVENTS.BID_WON, prebidEvent['bidWon']);
+
+      // Simulate "navigate away" behaviour
+      document.dispatchEvent(new Event('visibilitychange'));
 
       // Step 11: check the number of calls made to pubx.ai
       expect(navigator.sendBeacon.callCount).to.equal(2);
@@ -858,6 +884,9 @@ describe('pubxai analytics adapter', () => {
         ])
       );
 
+      // Simulate "navigate away" behaviour
+      document.dispatchEvent(new Event('visibilitychange'));
+
       // Step 13: check the number of calls made to pubx.ai
       expect(navigator.sendBeacon.callCount).to.equal(2);
 
@@ -872,6 +901,9 @@ describe('pubxai analytics adapter', () => {
           },
         ])
       );
+
+      // Simulate end of session
+      document.dispatchEvent(new Event('visibilitychange'));
 
       // Step 15: check the calls made to pubx.ai
       expect(navigator.sendBeacon.callCount).to.equal(4);
@@ -888,7 +920,7 @@ describe('pubxai analytics adapter', () => {
           prebidVersion: 'undefined', // not configured for test case
         });
         expect(expectedData.type).to.equal('text/json');
-        expect(JSON.parse(await expectedData.text())).to.deep.equal(
+        expect(JSON.parse(await expectedData.text())).to.deep.equal([
           auctionIdMapFn([expectedAfterBidWon, expectedAfterBid][index % 2], [
             {
               field: 'auctionId',
@@ -900,8 +932,125 @@ describe('pubxai analytics adapter', () => {
               updated: '1',
               replaced: '0',
             },
-          ])
+          ]),
+        ]);
+      }
+    });
+
+    it('2 concurrent auctions with batch sending', async () => {
+      // Step 1: Send auction init event for auction 1
+      events.emit(constants.EVENTS.AUCTION_INIT, prebidEvent['auctionInit']);
+
+      // Step 2: Send bid requested event for auction 1
+      events.emit(constants.EVENTS.BID_REQUESTED, prebidEvent['bidRequested']);
+
+      // Step 3: Send auction init event for auction 2
+      events.emit(
+        constants.EVENTS.AUCTION_INIT,
+        replaceProperty(prebidEvent['auctionInit'], [
+          {
+            field: 'auctionId',
+            updated: '"auction2"',
+            replaced: '"bc3806e4-873e-453c-8ae5-204f35e923b4"',
+          },
+        ])
+      );
+
+      // Step 4: Send bid requested event for auction 2
+      events.emit(
+        constants.EVENTS.BID_REQUESTED,
+        replaceProperty(prebidEvent['bidRequested'], [
+          {
+            field: 'auctionId',
+            updated: '"auction2"',
+            replaced: '"bc3806e4-873e-453c-8ae5-204f35e923b4"',
+          },
+        ])
+      );
+
+      // Step 5: Send bid response event for auction 1
+      events.emit(constants.EVENTS.BID_RESPONSE, prebidEvent['bidResponse']);
+
+      // Step 6: Send bid time out event for auction 1
+      events.emit(constants.EVENTS.BID_TIMEOUT, prebidEvent['bidTimeout']);
+
+      // Step 7: Send bid response event for auction 2
+      events.emit(
+        constants.EVENTS.BID_RESPONSE,
+        replaceProperty(prebidEvent['bidResponse'], [
+          {
+            field: 'auctionId',
+            updated: '"auction2"',
+            replaced: '"bc3806e4-873e-453c-8ae5-204f35e923b4"',
+          },
+        ])
+      );
+
+      // Step 8: Send auction end event for auction 1
+      events.emit(constants.EVENTS.AUCTION_END, prebidEvent['auctionEnd']);
+
+      // Step 9: Send auction bid won event for auction 1
+      events.emit(constants.EVENTS.BID_WON, prebidEvent['bidWon']);
+
+      // Step 10: Send auction end event for auction 2
+      events.emit(
+        constants.EVENTS.AUCTION_END,
+        replaceProperty(prebidEvent['auctionEnd'], [
+          {
+            field: 'auctionId',
+            updated: '"auction2"',
+            replaced: '"bc3806e4-873e-453c-8ae5-204f35e923b4"',
+          },
+        ])
+      );
+
+      // Step 11: Send auction bid won event for auction 2
+      events.emit(
+        constants.EVENTS.BID_WON,
+        replaceProperty(prebidEvent['bidWon'], [
+          {
+            field: 'auctionId',
+            updated: '"auction2"',
+            replaced: '"bc3806e4-873e-453c-8ae5-204f35e923b4"',
+          },
+        ])
+      );
+
+      // Step 12: check the number of calls made to pubx.ai
+      expect(navigator.sendBeacon.callCount).to.equal(0);
+
+      // Simulate end of session
+      document.dispatchEvent(new Event('visibilitychange'));
+
+      // Step 13: check the calls made to pubx.ai
+      expect(navigator.sendBeacon.callCount).to.equal(2);
+      for (const [index, arg] of navigator.sendBeacon.args.entries()) {
+        const [expectedUrl, expectedData] = arg;
+        const parsedUrl = new URL(expectedUrl);
+        expect(parsedUrl.pathname).to.equal(
+          ['/analytics/bidwon', '/analytics/auction'][index]
         );
+        expect(Object.fromEntries(parsedUrl.searchParams)).to.deep.equal({
+          auctionTimestamp: '1616654312804',
+          pubxaiAnalyticsVersion: 'v1.2.0',
+          prebidVersion: 'undefined', // not configured for test case
+        });
+        expect(expectedData.type).to.equal('text/json');
+        expect(JSON.parse(await expectedData.text())).to.deep.equal([
+          [expectedAfterBidWon, expectedAfterBid][index],
+          replaceProperty([expectedAfterBidWon, expectedAfterBid][index], [
+            {
+              field: 'auctionId',
+              updated: '"auction2"',
+              replaced: '"bc3806e4-873e-453c-8ae5-204f35e923b4"',
+            },
+            {
+              field: 'refreshRank',
+              updated: '1',
+              replaced: '0',
+            },
+          ]),
+        ]);
       }
     });
   });

--- a/test/spec/modules/pubxaiAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubxaiAnalyticsAdapter_spec.js
@@ -112,6 +112,13 @@ describe('pubxai analytics adapter', () => {
                 bidderWinsCount: 0,
               },
             ],
+            ortb2: {
+              device: {
+                ext: {
+                  cdep: true,
+                },
+              },
+            },
             auctionStart: 1603865707180,
             timeout: 1000,
             refererInfo: {
@@ -169,6 +176,13 @@ describe('pubxai analytics adapter', () => {
             bidderWinsCount: 0,
           },
         ],
+        ortb2: {
+          device: {
+            ext: {
+              cdep: true,
+            },
+          },
+        },
         auctionStart: 1603865707180,
         timeout: 1000,
         refererInfo: {
@@ -320,6 +334,13 @@ describe('pubxai analytics adapter', () => {
                 bidderWinsCount: 0,
               },
             ],
+            ortb2: {
+              device: {
+                ext: {
+                  cdep: true,
+                },
+              },
+            },
             auctionStart: 1603865707180,
             timeout: 1000,
             refererInfo: {
@@ -485,16 +506,6 @@ describe('pubxai analytics adapter', () => {
           },
         ],
       },
-      // pageDetail: {
-      //   host: location.host,
-      //   path: location.pathname,
-      //   search: location.search,
-      // },
-      // pmcDetail: {
-      //   bidDensity: storage.getItem("pbx:dpbid"),
-      //   maxBid: storage.getItem("pbx:mxbid"),
-      //   auctionId: storage.getItem("pbx:aucid"),
-      // },
     };
 
     let expectedAfterBid = {
@@ -553,7 +564,6 @@ describe('pubxai analytics adapter', () => {
         host: location.host,
         path: location.pathname,
         search: location.search,
-        adUnits: ['/19968336/header-bid-tag-1'],
       },
       floorDetail: {
         fetchStatus: 'success',
@@ -568,9 +578,13 @@ describe('pubxai analytics adapter', () => {
         deviceType: getDeviceType(),
         deviceOS: getOS(),
         browser: getBrowser(),
+        cdep: true,
       },
       userDetail: {
         userIdTypes: [],
+      },
+      consentDetail: {
+        consentTypes: [],
       },
       pmacDetail: JSON.parse(storage.getItem('pbx:pmac')) || {},
       initOptions: {
@@ -643,7 +657,6 @@ describe('pubxai analytics adapter', () => {
         host: location.host,
         path: location.pathname,
         search: location.search,
-        adUnits: ['/19968336/header-bid-tag-1'],
       },
       floorDetail: {
         fetchStatus: 'success',
@@ -658,9 +671,13 @@ describe('pubxai analytics adapter', () => {
         deviceType: getDeviceType(),
         deviceOS: getOS(),
         browser: getBrowser(),
+        cdep: true,
       },
       userDetail: {
         userIdTypes: [],
+      },
+      consentDetail: {
+        consentTypes: [],
       },
       pmacDetail: JSON.parse(storage.getItem('pbx:pmac')) || {},
       initOptions: {

--- a/test/spec/modules/pubxaiAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubxaiAnalyticsAdapter_spec.js
@@ -1,675 +1,694 @@
-import pubxaiAnalyticsAdapter, {getBrowser, getDeviceType, getOS} from 'modules/pubxaiAnalyticsAdapter.js';
-import {expect} from 'chai';
+import pubxaiAnalyticsAdapter, {
+  getDeviceType,
+  getOS,
+  getBrowser,
+  auctionCache,
+} from 'modules/pubxaiAnalyticsAdapter.js';
+import { expect } from 'chai';
 import adapterManager from 'src/adapterManager.js';
 import * as utils from 'src/utils.js';
-import {server} from 'test/mocks/xhr.js';
-import {getGptSlotInfoForAdUnitCode} from '../../../libraries/gptUtils/gptUtils.js';
+import { getGptSlotInfoForAdUnitCode } from '../../../libraries/gptUtils/gptUtils.js';
 
 let events = require('src/events');
 let constants = require('src/constants.json');
 
-describe('pubxai analytics adapter', function() {
-  beforeEach(function() {
+describe('pubxai analytics adapter', () => {
+  beforeEach(() => {
     sinon.stub(events, 'getEvents').returns([]);
   });
 
-  afterEach(function() {
+  afterEach(() => {
     events.getEvents.restore();
   });
 
-  describe('track', function() {
+  describe('track', () => {
     let initOptions = {
       samplingRate: '1',
-      pubxId: '6c415fc0-8b0e-4cf5-be73-01526a4db625'
+      pubxId: '6c415fc0-8b0e-4cf5-be73-01526a4db625',
     };
 
     let location = utils.getWindowLocation();
     let storage = window.top['sessionStorage'];
 
+    const replaceProperty = (obj, params) => {
+      let strObj = JSON.stringify(obj);
+      params.forEach(({ field, updated, replaced }) => {
+        strObj = strObj.replace(
+          new RegExp('"' + field + '":' + replaced, 'g'),
+          '"' + field + '":' + updated
+        );
+      });
+      return JSON.parse(strObj);
+    };
+
     let prebidEvent = {
-      'auctionInit': {
-        'auctionId': 'bc3806e4-873e-453c-8ae5-204f35e923b4',
-        'timestamp': 1603865707180,
-        'auctionStatus': 'inProgress',
-        'adUnits': [{
-          'code': '/19968336/header-bid-tag-1',
-          'mediaTypes': {
-            'banner': {
-              'sizes': [
-                [
-                  300,
-                  250
-                ]
-              ]
-            }
-          },
-          'bids': [{
-            'bidder': 'appnexus',
-            'params': {
-              'placementId': 13144370
+      auctionInit: {
+        auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
+        timestamp: 1603865707180,
+        auctionStatus: 'inProgress',
+        adUnits: [
+          {
+            code: '/19968336/header-bid-tag-1',
+            mediaTypes: {
+              banner: {
+                sizes: [[300, 250]],
+              },
             },
-            'auctionId': 'bc3806e4-873e-453c-8ae5-204f35e923b4',
-            'floorData': {
-              'skipped': false,
-              'skipRate': 0,
-              'modelVersion': 'test model 1.0',
-              'location': 'fetch',
-              'floorProvider': 'PubXFloorProvider',
-              'fetchStatus': 'success'
-            }
-          }],
-          'sizes': [
-            [
-              300,
-              250
-            ]
-          ],
-          'transactionId': '41ec8eaf-3e7c-4a8b-8344-ab796ff6e294'
-        }],
-        'adUnitCodes': [
-          '/19968336/header-bid-tag-1'
+            bids: [
+              {
+                bidder: 'appnexus',
+                params: {
+                  placementId: 13144370,
+                },
+                auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
+                floorData: {
+                  skipped: false,
+                  skipRate: 0,
+                  modelVersion: 'test model 1.0',
+                  location: 'fetch',
+                  floorProvider: 'PubXFloorProvider',
+                  fetchStatus: 'success',
+                },
+              },
+            ],
+            sizes: [[300, 250]],
+            transactionId: '41ec8eaf-3e7c-4a8b-8344-ab796ff6e294',
+          },
         ],
-        'bidderRequests': [{
-          'bidderCode': 'appnexus',
-          'auctionId': 'bc3806e4-873e-453c-8ae5-204f35e923b4',
-          'bidderRequestId': '184cbc05bb90ba',
-          'bids': [{
-            'bidder': 'appnexus',
-            'params': {
-              'placementId': 13144370
-            },
-            'auctionId': 'bc3806e4-873e-453c-8ae5-204f35e923b4',
-            'floorData': {
-              'skipped': false,
-              'skipRate': 0,
-              'modelVersion': 'test model 1.0',
-              'location': 'fetch',
-              'floorProvider': 'PubXFloorProvider',
-              'fetchStatus': 'success'
-            },
-            'mediaTypes': {
-              'banner': {
-                'sizes': [
-                  [
-                    300,
-                    250
-                  ]
-                ]
-              }
-            },
-            'adUnitCode': '/19968336/header-bid-tag-1',
-            'transactionId': '41ec8eaf-3e7c-4a8b-8344-ab796ff6e294',
-            'sizes': [
-              [
-                300,
-                250
-              ]
+        adUnitCodes: ['/19968336/header-bid-tag-1'],
+        bidderRequests: [
+          {
+            bidderCode: 'appnexus',
+            auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
+            bidderRequestId: '184cbc05bb90ba',
+            bids: [
+              {
+                bidder: 'appnexus',
+                params: {
+                  placementId: 13144370,
+                },
+                auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
+                floorData: {
+                  skipped: false,
+                  skipRate: 0,
+                  modelVersion: 'test model 1.0',
+                  location: 'fetch',
+                  floorProvider: 'PubXFloorProvider',
+                  fetchStatus: 'success',
+                },
+                mediaTypes: {
+                  banner: {
+                    sizes: [[300, 250]],
+                  },
+                },
+                adUnitCode: '/19968336/header-bid-tag-1',
+                transactionId: '41ec8eaf-3e7c-4a8b-8344-ab796ff6e294',
+                sizes: [[300, 250]],
+                bidId: '248f9a4489835e',
+                bidderRequestId: '184cbc05bb90ba',
+                src: 'client',
+                bidRequestsCount: 1,
+                bidderRequestsCount: 1,
+                bidderWinsCount: 0,
+              },
             ],
-            'bidId': '248f9a4489835e',
-            'bidderRequestId': '184cbc05bb90ba',
-            'src': 'client',
-            'bidRequestsCount': 1,
-            'bidderRequestsCount': 1,
-            'bidderWinsCount': 0
-          }],
-          'auctionStart': 1603865707180,
-          'timeout': 1000,
-          'refererInfo': {
-            'referer': 'http://local-pnh.net:8080/stream/',
-            'reachedTop': true,
-            'isAmp': false,
-            'numIframes': 0,
-            'stack': [
-              'http://local-pnh.net:8080/stream/'
-            ],
-            'canonicalUrl': null
-          },
-          'start': 1603865707182
-        }],
-        'noBids': [],
-        'bidsReceived': [],
-        'winningBids': [],
-        'timeout': 1000,
-        'config': {
-          'samplingRate': '1',
-          'pubxId': '6c415fc0-8b0e-4cf5-be73-01526a4db625'
-        }
-      },
-      'bidRequested': {
-        'bidderCode': 'appnexus',
-        'auctionId': 'bc3806e4-873e-453c-8ae5-204f35e923b4',
-        'bidderRequestId': '184cbc05bb90ba',
-        'bids': [{
-          'bidder': 'appnexus',
-          'params': {
-            'placementId': 13144370
-          },
-          'auctionId': 'bc3806e4-873e-453c-8ae5-204f35e923b4',
-          'floorData': {
-            'skipped': false,
-            'skipRate': 0,
-            'modelVersion': 'test model 1.0',
-            'location': 'fetch',
-            'floorProvider': 'PubXFloorProvider',
-            'fetchStatus': 'success'
-          },
-          'mediaTypes': {
-            'banner': {
-              'sizes': [
-                [
-                  300,
-                  250
-                ]
-              ]
-            }
-          },
-          'adUnitCode': '/19968336/header-bid-tag-1',
-          'transactionId': '41ec8eaf-3e7c-4a8b-8344-ab796ff6e294',
-          'sizes': [
-            [
-              300,
-              250
-            ]
-          ],
-          'bidId': '248f9a4489835e',
-          'bidderRequestId': '184cbc05bb90ba',
-          'src': 'client',
-          'bidRequestsCount': 1,
-          'bidderRequestsCount': 1,
-          'bidderWinsCount': 0
-        }],
-        'auctionStart': 1603865707180,
-        'timeout': 1000,
-        'refererInfo': {
-          'referer': 'http://local-pnh.net:8080/stream/',
-          'reachedTop': true,
-          'isAmp': false,
-          'numIframes': 0,
-          'stack': [
-            'http://local-pnh.net:8080/stream/'
-          ],
-          'canonicalUrl': null
-        },
-        'start': 1603865707182
-      },
-      'bidTimeout': [],
-      'bidResponse': {
-        'bidderCode': 'appnexus',
-        'width': 300,
-        'height': 250,
-        'statusMessage': 'Bid available',
-        'adId': '32780c4bc382cb',
-        'requestId': '248f9a4489835e',
-        'mediaType': 'banner',
-        'source': 'client',
-        'cpm': 0.5,
-        'creativeId': 96846035,
-        'currency': 'USD',
-        'netRevenue': true,
-        'ttl': 300,
-        'adUnitCode': '/19968336/header-bid-tag-1',
-        'appnexus': {
-          'buyerMemberId': 9325
-        },
-        'meta': {
-          'advertiserId': 2529885
-        },
-        'ad': '<!-- Creative 96846035 served by Member 9325 via AppNexus -->',
-        'originalCpm': 0.5,
-        'originalCurrency': 'USD',
-        'floorData': {
-          'fetchStatus': 'success',
-          'floorProvider': 'PubXFloorProvider',
-          'location': 'fetch',
-          'modelVersion': 'test model 1.0',
-          'skipRate': 0,
-          'skipped': false,
-          'floorValue': 0.4,
-          'floorRule': '/19968336/header-bid-tag-1|banner',
-          'floorCurrency': 'USD',
-          'cpmAfterAdjustments': 0.5,
-          'enforcements': {
-            'enforceJS': true,
-            'enforcePBS': false,
-            'floorDeals': true,
-            'bidAdjustment': true
-          },
-          'matchedFields': {
-            'gptSlot': '/19968336/header-bid-tag-1',
-            'mediaType': 'banner'
-          }
-        },
-        'auctionId': 'bc3806e4-873e-453c-8ae5-204f35e923b4',
-        'responseTimestamp': 1616654313071,
-        'requestTimestamp': 1616654312804,
-        'bidder': 'appnexus',
-        'timeToRespond': 267,
-        'pbLg': '0.50',
-        'pbMg': '0.50',
-        'pbHg': '0.50',
-        'pbAg': '0.50',
-        'pbDg': '0.50',
-        'pbCg': '0.50',
-        'size': '300x250',
-        'adserverTargeting': {
-          'hb_bidder': 'appnexus',
-          'hb_adid': '32780c4bc382cb',
-          'hb_pb': '0.50',
-          'hb_size': '300x250',
-          'hb_source': 'client',
-          'hb_format': 'banner'
-        },
-      },
-      'auctionEnd': {
-        'auctionId': 'bc3806e4-873e-453c-8ae5-204f35e923b4',
-        'timestamp': 1616654312804,
-        'auctionEnd': 1616654313090,
-        'auctionStatus': 'completed',
-        'adUnits': [{
-          'code': '/19968336/header-bid-tag-1',
-          'mediaTypes': {
-            'banner': {
-              'sizes': [
-                [
-                  300,
-                  250
-                ]
-              ]
-            }
-          },
-          'bids': [{
-            'bidder': 'appnexus',
-            'params': {
-              'placementId': 13144370
+            auctionStart: 1603865707180,
+            timeout: 1000,
+            refererInfo: {
+              referer: 'http://local-pnh.net:8080/stream/',
+              reachedTop: true,
+              isAmp: false,
+              numIframes: 0,
+              stack: ['http://local-pnh.net:8080/stream/'],
+              canonicalUrl: null,
             },
-            'auctionId': 'bc3806e4-873e-453c-8ae5-204f35e923b4',
-            'floorData': {
-              'skipped': false,
-              'skipRate': 0,
-              'modelVersion': 'test model 1.0',
-              'location': 'fetch',
-              'floorProvider': 'PubXFloorProvider',
-              'fetchStatus': 'success'
-            }
-          }],
-          'sizes': [
-            [
-              300,
-              250
-            ]
-          ],
-          'transactionId': '41ec8eaf-3e7c-4a8b-8344-ab796ff6e294'
-        }],
-        'adUnitCodes': [
-          '/19968336/header-bid-tag-1'
+            start: 1603865707182,
+          },
         ],
-        'bidderRequests': [{
-          'bidderCode': 'appnexus',
-          'auctionId': 'bc3806e4-873e-453c-8ae5-204f35e923b4',
-          'bidderRequestId': '184cbc05bb90ba',
-          'bids': [{
-            'bidder': 'appnexus',
-            'params': {
-              'placementId': 13144370
+        noBids: [],
+        bidsReceived: [],
+        winningBids: [],
+        timeout: 1000,
+        config: {
+          samplingRate: '1',
+          pubxId: '6c415fc0-8b0e-4cf5-be73-01526a4db625',
+        },
+      },
+      bidRequested: {
+        bidderCode: 'appnexus',
+        auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
+        bidderRequestId: '184cbc05bb90ba',
+        bids: [
+          {
+            bidder: 'appnexus',
+            params: {
+              placementId: 13144370,
             },
-            'auctionId': 'bc3806e4-873e-453c-8ae5-204f35e923b4',
-            'floorData': {
-              'skipped': false,
-              'skipRate': 0,
-              'modelVersion': 'test model 1.0',
-              'location': 'fetch',
-              'floorProvider': 'PubXFloorProvider',
-              'fetchStatus': 'success'
+            auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
+            floorData: {
+              skipped: false,
+              skipRate: 0,
+              modelVersion: 'test model 1.0',
+              location: 'fetch',
+              floorProvider: 'PubXFloorProvider',
+              fetchStatus: 'success',
             },
-            'mediaTypes': {
-              'banner': {
-                'sizes': [
-                  [
-                    300,
-                    250
-                  ]
-                ]
-              }
+            mediaTypes: {
+              banner: {
+                sizes: [[300, 250]],
+              },
             },
-            'adUnitCode': '/19968336/header-bid-tag-1',
-            'transactionId': '41ec8eaf-3e7c-4a8b-8344-ab796ff6e294',
-            'sizes': [
-              [
-                300,
-                250
-              ]
+            adUnitCode: '/19968336/header-bid-tag-1',
+            transactionId: '41ec8eaf-3e7c-4a8b-8344-ab796ff6e294',
+            sizes: [[300, 250]],
+            bidId: '248f9a4489835e',
+            bidderRequestId: '184cbc05bb90ba',
+            src: 'client',
+            bidRequestsCount: 1,
+            bidderRequestsCount: 1,
+            bidderWinsCount: 0,
+          },
+        ],
+        auctionStart: 1603865707180,
+        timeout: 1000,
+        refererInfo: {
+          referer: 'http://local-pnh.net:8080/stream/',
+          reachedTop: true,
+          isAmp: false,
+          numIframes: 0,
+          stack: ['http://local-pnh.net:8080/stream/'],
+          canonicalUrl: null,
+        },
+        start: 1603865707182,
+      },
+      bidTimeout: [],
+      bidResponse: {
+        bidderCode: 'appnexus',
+        width: 300,
+        height: 250,
+        statusMessage: 'Bid available',
+        adId: '32780c4bc382cb',
+        requestId: '248f9a4489835e',
+        mediaType: 'banner',
+        source: 'client',
+        cpm: 0.5,
+        creativeId: 96846035,
+        currency: 'USD',
+        netRevenue: true,
+        ttl: 300,
+        adUnitCode: '/19968336/header-bid-tag-1',
+        appnexus: {
+          buyerMemberId: 9325,
+        },
+        meta: {
+          advertiserId: 2529885,
+        },
+        ad: '<!-- Creative 96846035 served by Member 9325 via AppNexus -->',
+        originalCpm: 0.5,
+        originalCurrency: 'USD',
+        floorData: {
+          fetchStatus: 'success',
+          floorProvider: 'PubXFloorProvider',
+          location: 'fetch',
+          modelVersion: 'test model 1.0',
+          skipRate: 0,
+          skipped: false,
+          floorValue: 0.4,
+          floorRule: '/19968336/header-bid-tag-1|banner',
+          floorCurrency: 'USD',
+          cpmAfterAdjustments: 0.5,
+          enforcements: {
+            enforceJS: true,
+            enforcePBS: false,
+            floorDeals: true,
+            bidAdjustment: true,
+          },
+          matchedFields: {
+            gptSlot: '/19968336/header-bid-tag-1',
+            mediaType: 'banner',
+          },
+        },
+        auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
+        responseTimestamp: 1616654313071,
+        requestTimestamp: 1616654312804,
+        bidder: 'appnexus',
+        timeToRespond: 267,
+        pbLg: '0.50',
+        pbMg: '0.50',
+        pbHg: '0.50',
+        pbAg: '0.50',
+        pbDg: '0.50',
+        pbCg: '0.50',
+        size: '300x250',
+        adserverTargeting: {
+          hb_bidder: 'appnexus',
+          hb_adid: '32780c4bc382cb',
+          hb_pb: '0.50',
+          hb_size: '300x250',
+          hb_source: 'client',
+          hb_format: 'banner',
+        },
+      },
+      auctionEnd: {
+        auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
+        timestamp: 1616654312804,
+        auctionEnd: 1616654313090,
+        auctionStatus: 'completed',
+        adUnits: [
+          {
+            code: '/19968336/header-bid-tag-1',
+            mediaTypes: {
+              banner: {
+                sizes: [[300, 250]],
+              },
+            },
+            bids: [
+              {
+                bidder: 'appnexus',
+                params: {
+                  placementId: 13144370,
+                },
+                auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
+                floorData: {
+                  skipped: false,
+                  skipRate: 0,
+                  modelVersion: 'test model 1.0',
+                  location: 'fetch',
+                  floorProvider: 'PubXFloorProvider',
+                  fetchStatus: 'success',
+                },
+              },
             ],
-            'bidId': '248f9a4489835e',
-            'bidderRequestId': '184cbc05bb90ba',
-            'src': 'client',
-            'bidRequestsCount': 1,
-            'bidderRequestsCount': 1,
-            'bidderWinsCount': 0
-          }],
-          'auctionStart': 1603865707180,
-          'timeout': 1000,
-          'refererInfo': {
-            'referer': 'http://local-pnh.net:8080/stream/',
-            'reachedTop': true,
-            'isAmp': false,
-            'numIframes': 0,
-            'stack': [
-              'http://local-pnh.net:8080/stream/'
+            sizes: [[300, 250]],
+            transactionId: '41ec8eaf-3e7c-4a8b-8344-ab796ff6e294',
+          },
+        ],
+        adUnitCodes: ['/19968336/header-bid-tag-1'],
+        bidderRequests: [
+          {
+            bidderCode: 'appnexus',
+            auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
+            bidderRequestId: '184cbc05bb90ba',
+            bids: [
+              {
+                bidder: 'appnexus',
+                params: {
+                  placementId: 13144370,
+                },
+                auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
+                floorData: {
+                  skipped: false,
+                  skipRate: 0,
+                  modelVersion: 'test model 1.0',
+                  location: 'fetch',
+                  floorProvider: 'PubXFloorProvider',
+                  fetchStatus: 'success',
+                },
+                mediaTypes: {
+                  banner: {
+                    sizes: [[300, 250]],
+                  },
+                },
+                adUnitCode: '/19968336/header-bid-tag-1',
+                transactionId: '41ec8eaf-3e7c-4a8b-8344-ab796ff6e294',
+                sizes: [[300, 250]],
+                bidId: '248f9a4489835e',
+                bidderRequestId: '184cbc05bb90ba',
+                src: 'client',
+                bidRequestsCount: 1,
+                bidderRequestsCount: 1,
+                bidderWinsCount: 0,
+              },
             ],
-            'canonicalUrl': null
-          },
-          'start': 1603865707182
-        }],
-        'noBids': [],
-        'bidsReceived': [{
-          'bidderCode': 'appnexus',
-          'width': 300,
-          'height': 250,
-          'statusMessage': 'Bid available',
-          'adId': '32780c4bc382cb',
-          'requestId': '248f9a4489835e',
-          'mediaType': 'banner',
-          'source': 'client',
-          'cpm': 0.5,
-          'creativeId': 96846035,
-          'currency': 'USD',
-          'netRevenue': true,
-          'ttl': 300,
-          'adUnitCode': '/19968336/header-bid-tag-1',
-          'appnexus': {
-            'buyerMemberId': 9325
-          },
-          'meta': {
-            'advertiserId': 2529885
-          },
-          'ad': '<!-- Creative 96846035 served by Member 9325 via AppNexus -->',
-          'originalCpm': 0.5,
-          'originalCurrency': 'USD',
-          'floorData': {
-            'fetchStatus': 'success',
-            'floorProvider': 'PubXFloorProvider',
-            'location': 'fetch',
-            'modelVersion': 'test model 1.0',
-            'skipRate': 0,
-            'skipped': false,
-            'floorValue': 0.4,
-            'floorRule': '/19968336/header-bid-tag-1|banner',
-            'floorCurrency': 'USD',
-            'cpmAfterAdjustments': 0.5,
-            'enforcements': {
-              'enforceJS': true,
-              'enforcePBS': false,
-              'floorDeals': true,
-              'bidAdjustment': true
+            auctionStart: 1603865707180,
+            timeout: 1000,
+            refererInfo: {
+              referer: 'http://local-pnh.net:8080/stream/',
+              reachedTop: true,
+              isAmp: false,
+              numIframes: 0,
+              stack: ['http://local-pnh.net:8080/stream/'],
+              canonicalUrl: null,
             },
-            'matchedFields': {
-              'gptSlot': '/19968336/header-bid-tag-1',
-              'mediaType': 'banner'
-            }
+            start: 1603865707182,
           },
-          'auctionId': 'bc3806e4-873e-453c-8ae5-204f35e923b4',
-          'responseTimestamp': 1616654313071,
-          'requestTimestamp': 1616654312804,
-          'bidder': 'appnexus',
-          'timeToRespond': 267,
-          'pbLg': '0.50',
-          'pbMg': '0.50',
-          'pbHg': '0.50',
-          'pbAg': '0.50',
-          'pbDg': '0.50',
-          'pbCg': '0.50',
-          'size': '300x250',
-          'adserverTargeting': {
-            'hb_bidder': 'appnexus',
-            'hb_adid': '32780c4bc382cb',
-            'hb_pb': '0.50',
-            'hb_size': '300x250',
-            'hb_source': 'client',
-            'hb_format': 'banner'
+        ],
+        noBids: [],
+        bidsReceived: [
+          {
+            bidderCode: 'appnexus',
+            width: 300,
+            height: 250,
+            statusMessage: 'Bid available',
+            adId: '32780c4bc382cb',
+            requestId: '248f9a4489835e',
+            mediaType: 'banner',
+            source: 'client',
+            cpm: 0.5,
+            creativeId: 96846035,
+            currency: 'USD',
+            netRevenue: true,
+            ttl: 300,
+            adUnitCode: '/19968336/header-bid-tag-1',
+            appnexus: {
+              buyerMemberId: 9325,
+            },
+            meta: {
+              advertiserId: 2529885,
+            },
+            ad: '<!-- Creative 96846035 served by Member 9325 via AppNexus -->',
+            originalCpm: 0.5,
+            originalCurrency: 'USD',
+            floorData: {
+              fetchStatus: 'success',
+              floorProvider: 'PubXFloorProvider',
+              location: 'fetch',
+              modelVersion: 'test model 1.0',
+              skipRate: 0,
+              skipped: false,
+              floorValue: 0.4,
+              floorRule: '/19968336/header-bid-tag-1|banner',
+              floorCurrency: 'USD',
+              cpmAfterAdjustments: 0.5,
+              enforcements: {
+                enforceJS: true,
+                enforcePBS: false,
+                floorDeals: true,
+                bidAdjustment: true,
+              },
+              matchedFields: {
+                gptSlot: '/19968336/header-bid-tag-1',
+                mediaType: 'banner',
+              },
+            },
+            auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
+            responseTimestamp: 1616654313071,
+            requestTimestamp: 1616654312804,
+            bidder: 'appnexus',
+            timeToRespond: 267,
+            pbLg: '0.50',
+            pbMg: '0.50',
+            pbHg: '0.50',
+            pbAg: '0.50',
+            pbDg: '0.50',
+            pbCg: '0.50',
+            size: '300x250',
+            adserverTargeting: {
+              hb_bidder: 'appnexus',
+              hb_adid: '32780c4bc382cb',
+              hb_pb: '0.50',
+              hb_size: '300x250',
+              hb_source: 'client',
+              hb_format: 'banner',
+            },
+            status: 'rendered',
+            params: [
+              {
+                placementId: 13144370,
+              },
+            ],
           },
-          'status': 'rendered',
-          'params': [{
-            'placementId': 13144370
-          }]
-        }],
-        'winningBids': [],
-        'timeout': 1000
+        ],
+        winningBids: [],
+        timeout: 1000,
       },
-      'bidWon': {
-        'bidderCode': 'appnexus',
-        'width': 300,
-        'height': 250,
-        'statusMessage': 'Bid available',
-        'adId': '32780c4bc382cb',
-        'requestId': '248f9a4489835e',
-        'mediaType': 'banner',
-        'source': 'client',
-        'cpm': 0.5,
-        'creativeId': 96846035,
-        'currency': 'USD',
-        'netRevenue': true,
-        'ttl': 300,
-        'adUnitCode': '/19968336/header-bid-tag-1',
-        'appnexus': {
-          'buyerMemberId': 9325
+      bidWon: {
+        bidderCode: 'appnexus',
+        width: 300,
+        height: 250,
+        statusMessage: 'Bid available',
+        adId: '32780c4bc382cb',
+        requestId: '248f9a4489835e',
+        mediaType: 'banner',
+        source: 'client',
+        cpm: 0.5,
+        creativeId: 96846035,
+        currency: 'USD',
+        netRevenue: true,
+        ttl: 300,
+        adUnitCode: '/19968336/header-bid-tag-1',
+        appnexus: {
+          buyerMemberId: 9325,
         },
-        'meta': {
-          'advertiserId': 2529885
+        meta: {
+          advertiserId: 2529885,
         },
-        'ad': '<!-- Creative 96846035 served by Member 9325 via AppNexus -->',
-        'originalCpm': 0.5,
-        'originalCurrency': 'USD',
-        'floorData': {
-          'fetchStatus': 'success',
-          'floorProvider': 'PubXFloorProvider',
-          'location': 'fetch',
-          'modelVersion': 'test model 1.0',
-          'skipRate': 0,
-          'skipped': false,
-          'floorValue': 0.4,
-          'floorRule': '/19968336/header-bid-tag-1|banner',
-          'floorCurrency': 'USD',
-          'cpmAfterAdjustments': 0.5,
-          'enforcements': {
-            'enforceJS': true,
-            'enforcePBS': false,
-            'floorDeals': true,
-            'bidAdjustment': true
+        ad: '<!-- Creative 96846035 served by Member 9325 via AppNexus -->',
+        originalCpm: 0.5,
+        originalCurrency: 'USD',
+        floorData: {
+          fetchStatus: 'success',
+          floorProvider: 'PubXFloorProvider',
+          location: 'fetch',
+          modelVersion: 'test model 1.0',
+          skipRate: 0,
+          skipped: false,
+          floorValue: 0.4,
+          floorRule: '/19968336/header-bid-tag-1|banner',
+          floorCurrency: 'USD',
+          cpmAfterAdjustments: 0.5,
+          enforcements: {
+            enforceJS: true,
+            enforcePBS: false,
+            floorDeals: true,
+            bidAdjustment: true,
           },
-          'matchedFields': {
-            'gptSlot': '/19968336/header-bid-tag-1',
-            'mediaType': 'banner'
-          }
+          matchedFields: {
+            gptSlot: '/19968336/header-bid-tag-1',
+            mediaType: 'banner',
+          },
         },
-        'auctionId': 'bc3806e4-873e-453c-8ae5-204f35e923b4',
-        'responseTimestamp': 1616654313071,
-        'requestTimestamp': 1616654312804,
-        'bidder': 'appnexus',
-        'timeToRespond': 267,
-        'pbLg': '0.50',
-        'pbMg': '0.50',
-        'pbHg': '0.50',
-        'pbAg': '0.50',
-        'pbDg': '0.50',
-        'pbCg': '0.50',
-        'size': '300x250',
-        'adserverTargeting': {
-          'hb_bidder': 'appnexus',
-          'hb_adid': '32780c4bc382cb',
-          'hb_pb': '0.50',
-          'hb_size': '300x250',
-          'hb_source': 'client',
-          'hb_format': 'banner'
+        auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
+        responseTimestamp: 1616654313071,
+        requestTimestamp: 1616654312804,
+        bidder: 'appnexus',
+        timeToRespond: 267,
+        pbLg: '0.50',
+        pbMg: '0.50',
+        pbHg: '0.50',
+        pbAg: '0.50',
+        pbDg: '0.50',
+        pbCg: '0.50',
+        size: '300x250',
+        adserverTargeting: {
+          hb_bidder: 'appnexus',
+          hb_adid: '32780c4bc382cb',
+          hb_pb: '0.50',
+          hb_size: '300x250',
+          hb_source: 'client',
+          hb_format: 'banner',
         },
-        'status': 'rendered',
-        'params': [{
-          'placementId': 13144370
-        }]
+        status: 'rendered',
+        params: [
+          {
+            placementId: 13144370,
+          },
+        ],
       },
-      'pageDetail': {
-        'host': location.host,
-        'path': location.pathname,
-        'search': location.search
-      },
-      'pmcDetail': {
-        'bidDensity': storage.getItem('pbx:dpbid'),
-        'maxBid': storage.getItem('pbx:mxbid'),
-        'auctionId': storage.getItem('pbx:aucid')
-      }
+      // pageDetail: {
+      //   host: location.host,
+      //   path: location.pathname,
+      //   search: location.search,
+      // },
+      // pmcDetail: {
+      //   bidDensity: storage.getItem("pbx:dpbid"),
+      //   maxBid: storage.getItem("pbx:mxbid"),
+      //   auctionId: storage.getItem("pbx:aucid"),
+      // },
     };
 
     let expectedAfterBid = {
-      'bids': [{
-        'bidderCode': 'appnexus',
-        'bidId': '248f9a4489835e',
-        'adUnitCode': '/19968336/header-bid-tag-1',
-        'gptSlotCode': getGptSlotInfoForAdUnitCode('/19968336/header-bid-tag-1').gptSlot || null,
-        'auctionId': 'bc3806e4-873e-453c-8ae5-204f35e923b4',
-        'sizes': '300x250',
-        'renderStatus': 2,
-        'requestTimestamp': 1616654312804,
-        'creativeId': 96846035,
-        'currency': 'USD',
-        'cpm': 0.5,
-        'netRevenue': true,
-        'mediaType': 'banner',
-        'statusMessage': 'Bid available',
-        'floorData': {
-          'fetchStatus': 'success',
-          'floorProvider': 'PubXFloorProvider',
-          'location': 'fetch',
-          'modelVersion': 'test model 1.0',
-          'skipRate': 0,
-          'skipped': false,
-          'floorValue': 0.4,
-          'floorRule': '/19968336/header-bid-tag-1|banner',
-          'floorCurrency': 'USD',
-          'cpmAfterAdjustments': 0.5,
-          'enforcements': {
-            'enforceJS': true,
-            'enforcePBS': false,
-            'floorDeals': true,
-            'bidAdjustment': true
+      bids: [
+        {
+          bidderCode: 'appnexus',
+          bidId: '248f9a4489835e',
+          adUnitCode: '/19968336/header-bid-tag-1',
+          gptSlotCode:
+            getGptSlotInfoForAdUnitCode('/19968336/header-bid-tag-1').gptSlot ||
+            null,
+          auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
+          sizes: '300x250',
+          renderStatus: 2,
+          requestTimestamp: 1616654312804,
+          creativeId: 96846035,
+          currency: 'USD',
+          cpm: 0.5,
+          netRevenue: true,
+          mediaType: 'banner',
+          statusMessage: 'Bid available',
+          floorData: {
+            fetchStatus: 'success',
+            floorProvider: 'PubXFloorProvider',
+            location: 'fetch',
+            modelVersion: 'test model 1.0',
+            skipRate: 0,
+            skipped: false,
+            floorValue: 0.4,
+            floorRule: '/19968336/header-bid-tag-1|banner',
+            floorCurrency: 'USD',
+            cpmAfterAdjustments: 0.5,
+            enforcements: {
+              enforceJS: true,
+              enforcePBS: false,
+              floorDeals: true,
+              bidAdjustment: true,
+            },
+            matchedFields: {
+              gptSlot: '/19968336/header-bid-tag-1',
+              mediaType: 'banner',
+            },
           },
-          'matchedFields': {
-            'gptSlot': '/19968336/header-bid-tag-1',
-            'mediaType': 'banner'
-          }
+          placementId: null,
+          timeToRespond: 267,
+          responseTimestamp: 1616654313071,
         },
-        'timeToRespond': 267,
-        'responseTimestamp': 1616654313071
-      }],
-      'pageDetail': {
-        'host': location.host,
-        'path': location.pathname,
-        'search': location.search,
-        'adUnits': [
-          '/19968336/header-bid-tag-1'
-        ]
+      ],
+      auctionDetail: {
+        adUnitCodes: ['/19968336/header-bid-tag-1'],
+        auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
+        refreshRank: 0,
+        timestamp: 1616654312804,
       },
-      'floorDetail': {
-        'fetchStatus': 'success',
-        'floorProvider': 'PubXFloorProvider',
-        'location': 'fetch',
-        'modelVersion': 'test model 1.0',
-        'skipRate': 0,
-        'skipped': false
+      pageDetail: {
+        host: location.host,
+        path: location.pathname,
+        search: location.search,
+        adUnits: ['/19968336/header-bid-tag-1'],
       },
-      'deviceDetail': {
-        'platform': navigator.platform,
-        'deviceType': getDeviceType(),
-        'deviceOS': getOS(),
-        'browser': getBrowser()
+      floorDetail: {
+        fetchStatus: 'success',
+        floorProvider: 'PubXFloorProvider',
+        location: 'fetch',
+        modelVersion: 'test model 1.0',
+        skipRate: 0,
+        skipped: false,
       },
-      'pmcDetail': {
-        'bidDensity': storage.getItem('pbx:dpbid'),
-        'maxBid': storage.getItem('pbx:mxbid'),
-        'auctionId': storage.getItem('pbx:aucid')
+      deviceDetail: {
+        platform: navigator.platform,
+        deviceType: getDeviceType(),
+        deviceOS: getOS(),
+        browser: getBrowser(),
       },
-      'initOptions': initOptions
+      userDetail: {
+        userIdTypes: [],
+      },
+      pmacDetail: JSON.parse(storage.getItem('pbx:pmac')) || {},
+      initOptions: {
+        ...initOptions,
+        auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
+      },
     };
 
     let expectedAfterBidWon = {
-      'winningBid': {
-        'adUnitCode': '/19968336/header-bid-tag-1',
-        'gptSlotCode': getGptSlotInfoForAdUnitCode('/19968336/header-bid-tag-1').gptSlot || null,
-        'auctionId': 'bc3806e4-873e-453c-8ae5-204f35e923b4',
-        'bidderCode': 'appnexus',
-        'bidId': '248f9a4489835e',
-        'cpm': 0.5,
-        'creativeId': 96846035,
-        'currency': 'USD',
-        'floorData': {
-          'fetchStatus': 'success',
-          'floorProvider': 'PubXFloorProvider',
-          'location': 'fetch',
-          'modelVersion': 'test model 1.0',
-          'skipRate': 0,
-          'skipped': false,
-          'floorValue': 0.4,
-          'floorRule': '/19968336/header-bid-tag-1|banner',
-          'floorCurrency': 'USD',
-          'cpmAfterAdjustments': 0.5,
-          'enforcements': {
-            'enforceJS': true,
-            'enforcePBS': false,
-            'floorDeals': true,
-            'bidAdjustment': true
+      winningBid: {
+        adUnitCode: '/19968336/header-bid-tag-1',
+        gptSlotCode:
+          getGptSlotInfoForAdUnitCode('/19968336/header-bid-tag-1').gptSlot ||
+          null,
+        auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
+        bidderCode: 'appnexus',
+        bidId: '248f9a4489835e',
+        cpm: 0.5,
+        creativeId: 96846035,
+        currency: 'USD',
+        floorData: {
+          fetchStatus: 'success',
+          floorProvider: 'PubXFloorProvider',
+          location: 'fetch',
+          modelVersion: 'test model 1.0',
+          skipRate: 0,
+          skipped: false,
+          floorValue: 0.4,
+          floorRule: '/19968336/header-bid-tag-1|banner',
+          floorCurrency: 'USD',
+          cpmAfterAdjustments: 0.5,
+          enforcements: {
+            enforceJS: true,
+            enforcePBS: false,
+            floorDeals: true,
+            bidAdjustment: true,
           },
-          'matchedFields': {
-            'gptSlot': '/19968336/header-bid-tag-1',
-            'mediaType': 'banner'
-          }
+          matchedFields: {
+            gptSlot: '/19968336/header-bid-tag-1',
+            mediaType: 'banner',
+          },
         },
-        'floorProvider': 'PubXFloorProvider',
-        'floorFetchStatus': 'success',
-        'floorLocation': 'fetch',
-        'floorModelVersion': 'test model 1.0',
-        'floorSkipRate': 0,
-        'isFloorSkipped': false,
-        'isWinningBid': true,
-        'mediaType': 'banner',
-        'netRevenue': true,
-        'placementId': 13144370,
-        'renderedSize': '300x250',
-        'renderStatus': 4,
-        'responseTimestamp': 1616654313071,
-        'requestTimestamp': 1616654312804,
-        'status': 'rendered',
-        'statusMessage': 'Bid available',
-        'timeToRespond': 267
+        adServerData: {},
+        floorProvider: 'PubXFloorProvider',
+        floorFetchStatus: 'success',
+        floorLocation: 'fetch',
+        floorModelVersion: 'test model 1.0',
+        floorSkipRate: 0,
+        isFloorSkipped: false,
+        isWinningBid: true,
+        mediaType: 'banner',
+        netRevenue: true,
+        placementId: 13144370,
+        renderedSize: '300x250',
+        sizes: '300x250',
+        renderStatus: 4,
+        responseTimestamp: 1616654313071,
+        requestTimestamp: 1616654312804,
+        status: 'rendered',
+        statusMessage: 'Bid available',
+        timeToRespond: 267,
       },
-      'pageDetail': {
-        'host': location.host,
-        'path': location.pathname,
-        'search': location.search
+      auctionDetail: {
+        adUnitCodes: ['/19968336/header-bid-tag-1'],
+        auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
+        refreshRank: 0,
+        timestamp: 1616654312804,
       },
-      'deviceDetail': {
-        'platform': navigator.platform,
-        'deviceType': getDeviceType(),
-        'deviceOS': getOS(),
-        'browser': getBrowser()
+      pageDetail: {
+        host: location.host,
+        path: location.pathname,
+        search: location.search,
+        adUnits: ['/19968336/header-bid-tag-1'],
       },
-      'initOptions': initOptions
-    }
+      floorDetail: {
+        fetchStatus: 'success',
+        floorProvider: 'PubXFloorProvider',
+        location: 'fetch',
+        modelVersion: 'test model 1.0',
+        skipRate: 0,
+        skipped: false,
+      },
+      deviceDetail: {
+        platform: navigator.platform,
+        deviceType: getDeviceType(),
+        deviceOS: getOS(),
+        browser: getBrowser(),
+      },
+      userDetail: {
+        userIdTypes: [],
+      },
+      pmacDetail: JSON.parse(storage.getItem('pbx:pmac')) || {},
+      initOptions: {
+        ...initOptions,
+        auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
+      },
+    };
 
     adapterManager.registerAnalyticsAdapter({
       code: 'pubxai',
-      adapter: pubxaiAnalyticsAdapter
+      adapter: pubxaiAnalyticsAdapter,
     });
 
-    beforeEach(function() {
+    beforeEach(() => {
       adapterManager.enableAnalytics({
         provider: 'pubxai',
-        options: initOptions
+        options: initOptions,
       });
+      sinon.stub(navigator, 'sendBeacon').returns(true);
     });
 
-    afterEach(function() {
+    afterEach(() => {
       pubxaiAnalyticsAdapter.disableAnalytics();
+      navigator.sendBeacon.restore();
+      delete auctionCache['bc3806e4-873e-453c-8ae5-204f35e923b4'];
     });
 
-    it('builds and sends auction data', function() {
+    it('builds and sends auction data', async () => {
       // Step 1: Send auction init event
       events.emit(constants.EVENTS.AUCTION_INIT, prebidEvent['auctionInit']);
 
@@ -685,20 +704,188 @@ describe('pubxai analytics adapter', function() {
       // Step 5: Send auction end event
       events.emit(constants.EVENTS.AUCTION_END, prebidEvent['auctionEnd']);
 
-      expect(server.requests.length).to.equal(1);
-
-      let realAfterBid = JSON.parse(server.requests[0].requestBody);
-
-      expect(realAfterBid).to.deep.equal(expectedAfterBid);
+      expect(navigator.sendBeacon.callCount).to.equal(0);
 
       // Step 6: Send auction bid won event
       events.emit(constants.EVENTS.BID_WON, prebidEvent['bidWon']);
 
-      expect(server.requests.length).to.equal(2);
+      expect(navigator.sendBeacon.callCount).to.equal(2);
 
-      let winEventData = JSON.parse(server.requests[1].requestBody);
+      for (const [index, arg] of navigator.sendBeacon.args.entries()) {
+        const [expectedUrl, expectedData] = arg;
+        const parsedUrl = new URL(expectedUrl);
+        expect(parsedUrl.pathname).to.equal(
+          ['/analytics/bidwon', '/analytics/auction'][index]
+        );
+        expect(Object.fromEntries(parsedUrl.searchParams)).to.deep.equal({
+          auctionTimestamp: '1616654312804',
+          pubxaiAnalyticsVersion: 'v1.2.0',
+          prebidVersion: 'undefined', // not configured for test case
+        });
+        expect(expectedData.type).to.equal('text/json');
+        expect(JSON.parse(await expectedData.text())).to.deep.equal(
+          [expectedAfterBidWon, expectedAfterBid][index]
+        );
+      }
+    });
 
-      expect(winEventData).to.deep.equal(expectedAfterBidWon);
+    it('auction with no bids', async () => {
+      // Step 1: Send auction init event
+      events.emit(constants.EVENTS.AUCTION_INIT, prebidEvent['auctionInit']);
+
+      // Step 2: Send bid requested event
+      events.emit(constants.EVENTS.BID_REQUESTED, prebidEvent['bidRequested']);
+
+      // Step 3: Send bid time out event
+      events.emit(constants.EVENTS.BID_TIMEOUT, prebidEvent['bidTimeout']);
+
+      // Step 4: check the number of calls made to pubx.ai
+      expect(navigator.sendBeacon.callCount).to.equal(0);
+
+      // Step 5: Send auction end event
+      events.emit(constants.EVENTS.AUCTION_END, prebidEvent['auctionEnd']);
+
+      // Step 6: check the number of calls made to pubx.ai
+      expect(navigator.sendBeacon.callCount).to.equal(1);
+
+      // Step 7: check the pathname of the calls is correct (sent only to the auction endpoint)
+      const [expectedUrl, expectedData] = navigator.sendBeacon.args[0];
+      const parsedUrl = new URL(expectedUrl);
+      expect(parsedUrl.pathname).to.equal('/analytics/auction');
+
+      // Step 8: check that the meta information in the call is correct
+      expect(Object.fromEntries(parsedUrl.searchParams)).to.deep.equal({
+        auctionTimestamp: '1616654312804',
+        pubxaiAnalyticsVersion: 'v1.2.0',
+        prebidVersion: 'undefined', // not configured for test case
+      });
+
+      // Step 9: check that the data sent in the request is correct
+      expect(expectedData.type).to.equal('text/json');
+      expect(JSON.parse(await expectedData.text())).to.deep.equal({
+        ...expectedAfterBid,
+        bids: [],
+      });
+    });
+
+    it('2 concurrent auctions', async () => {
+      // Step 1: Send auction init event for auction 1
+      events.emit(constants.EVENTS.AUCTION_INIT, prebidEvent['auctionInit']);
+
+      // Step 2: Send bid requested event for auction 1
+      events.emit(constants.EVENTS.BID_REQUESTED, prebidEvent['bidRequested']);
+
+      // Step 3: Send auction init event for auction 2
+      events.emit(
+        constants.EVENTS.AUCTION_INIT,
+        replaceProperty(prebidEvent['auctionInit'], [
+          {
+            field: 'auctionId',
+            updated: '"auction2"',
+            replaced: '"bc3806e4-873e-453c-8ae5-204f35e923b4"',
+          },
+        ])
+      );
+
+      // Step 4: Send bid requested event for auction 2
+      events.emit(
+        constants.EVENTS.BID_REQUESTED,
+        replaceProperty(prebidEvent['bidRequested'], [
+          {
+            field: 'auctionId',
+            updated: '"auction2"',
+            replaced: '"bc3806e4-873e-453c-8ae5-204f35e923b4"',
+          },
+        ])
+      );
+
+      // Step 5: Send bid response event for auction 1
+      events.emit(constants.EVENTS.BID_RESPONSE, prebidEvent['bidResponse']);
+
+      // Step 6: Send bid time out event for auction 1
+      events.emit(constants.EVENTS.BID_TIMEOUT, prebidEvent['bidTimeout']);
+
+      // Step 7: Send bid response event for auction 2
+      events.emit(
+        constants.EVENTS.BID_RESPONSE,
+        replaceProperty(prebidEvent['bidResponse'], [
+          {
+            field: 'auctionId',
+            updated: '"auction2"',
+            replaced: '"bc3806e4-873e-453c-8ae5-204f35e923b4"',
+          },
+        ])
+      );
+
+      // Step 8: Send auction end event for auction 1
+      events.emit(constants.EVENTS.AUCTION_END, prebidEvent['auctionEnd']);
+
+      // Step 9: check the number of calls made to pubx.ai
+      expect(navigator.sendBeacon.callCount).to.equal(0);
+
+      // Step 10: Send auction bid won event for auction 1
+      events.emit(constants.EVENTS.BID_WON, prebidEvent['bidWon']);
+
+      // Step 11: check the number of calls made to pubx.ai
+      expect(navigator.sendBeacon.callCount).to.equal(2);
+
+      // Step 12: Send auction end event for auction 2
+      events.emit(
+        constants.EVENTS.AUCTION_END,
+        replaceProperty(prebidEvent['auctionEnd'], [
+          {
+            field: 'auctionId',
+            updated: '"auction2"',
+            replaced: '"bc3806e4-873e-453c-8ae5-204f35e923b4"',
+          },
+        ])
+      );
+
+      // Step 13: check the number of calls made to pubx.ai
+      expect(navigator.sendBeacon.callCount).to.equal(2);
+
+      // Step 14: Send auction bid won event for auction 2
+      events.emit(
+        constants.EVENTS.BID_WON,
+        replaceProperty(prebidEvent['bidWon'], [
+          {
+            field: 'auctionId',
+            updated: '"auction2"',
+            replaced: '"bc3806e4-873e-453c-8ae5-204f35e923b4"',
+          },
+        ])
+      );
+
+      // Step 15: check the calls made to pubx.ai
+      expect(navigator.sendBeacon.callCount).to.equal(4);
+      for (const [index, arg] of navigator.sendBeacon.args.entries()) {
+        const [expectedUrl, expectedData] = arg;
+        const parsedUrl = new URL(expectedUrl);
+        const auctionIdMapFn = index < 2 ? (i, _) => i : replaceProperty;
+        expect(parsedUrl.pathname).to.equal(
+          ['/analytics/bidwon', '/analytics/auction'][index % 2]
+        );
+        expect(Object.fromEntries(parsedUrl.searchParams)).to.deep.equal({
+          auctionTimestamp: '1616654312804',
+          pubxaiAnalyticsVersion: 'v1.2.0',
+          prebidVersion: 'undefined', // not configured for test case
+        });
+        expect(expectedData.type).to.equal('text/json');
+        expect(JSON.parse(await expectedData.text())).to.deep.equal(
+          auctionIdMapFn([expectedAfterBidWon, expectedAfterBid][index % 2], [
+            {
+              field: 'auctionId',
+              updated: '"auction2"',
+              replaced: '"bc3806e4-873e-453c-8ae5-204f35e923b4"',
+            },
+            {
+              field: 'refreshRank',
+              updated: '1',
+              replaced: '0',
+            },
+          ])
+        );
+      }
     });
   });
 });


### PR DESCRIPTION
Ticket: [PTOW-2](https://pubai.atlassian.net/browse/PTOW-2)

Task: update the pubx analytics adapter, to make use of more modern approaches and to consume more data.

Implements:
- Using beacons to send data to pubx endpoints.
  - The beacon preserves the content type of the data.
- Deep copy of the data is sent to pubx, and is not modified throughout the auction (done). 
  - The data sent back is cloned before send. 
  - Each of the properties present in the auction is either not taken from the auction itself, or taken as a deep copy
- Sample the auction and winning bids together.
  - The sampling uses a hash of the auction id, so that wins and auctions are sampled together. 
  - The sampling is _not_ done on the page level, to avoid skewing sampling towards "repeat" auctions, which are less valuable. 
- verification of the rank of the auction on the page.
  - as auctions are held, their rank in time is preserved. 
  - This auction rank is not specific to an adslot, but global to the page.
  - I have observed consistent behaviour that an auction can have multiple winning bids, each independently rendered. In this case the auction rank is not incremented/repeated, as no auction is held to promote a new winning bid to render.
- Google object data (key value pairs)
  - The google ad server data is constructed before the bidwon event from prebid
  - i was unable to observe any occasion where GAM rendering did not trigger a prebid win event
  - the gam data is tied to an ad slot, and as mentioned above, single auctions were observed rendering many winning bids into the same slot, making tracking the specific GPT KVPs for a bid _impossible_. The KVPs associated to the winning bid are the KVPs available at the time of the winning bid event firing in prebid.
- PMAC data
  - as requested via slack, the PMAC data is loaded from session storage, and expected to be partitioned by auction id. 
  - no data manipulation was done on the pmac data from local storage
- user ids
  - captured from the prebid globals. The types of user ids _only_ are recorded, but the schema could be expanded to support more user information in future.
- Floor price in case of no bids
  - there is a wonderful variable in the priceFloors.js module, _floorDataForAuction, which contains _all_ information, derived or otherwise, regarding the price floor information of an auction, up to 3 seconds after the auction ends. Try as i might, i am unable to record the data from this meta variable.
  - i am pulling price data from the ad unit bids of the prebid auction. The "bid" property of an ad unit is declared by the publisher, and then augmented by the price floors module later in the auction lifecycle. In the event that no bids occur, the ad units will still exist, and the "bid" property of the ad unit, which defines the bidders that should provide responses, is also still defined.
- concurrency support
  - I observed several cases of multiple auctions running concurrently across the ad units of a page. Typically it seems that rather than bundle multiple ad units into one auction, each ad unit has a separate auction. We used to aggregate all bids for "an auction" under one list, and then send the array of bids back as part of the same auction. This meant that regularly, the bids attributed to a single auction were actually part of many auctions, and so the floor data we sent back was messed up (being derived from the first bid)

Not implemented:
- viewability
  - i attempted to use the gpt viewbility module, and because auctions can have multiple winning bids, but the gpt event can only track at the slot level, it was not possible to create a mapping between a bid and a "view event"
  - attempting to use the intersection observer didn't yield sensible results. I attempted to update the insersection observers data in realtime before the send to pubx, which didn't produce good/reliable/accurate viewability results, and attempting to leave the data to the initial data recorded by the observer was similarly inaccurate.
  - attempting to "construct" a viewable event (i.e 50% in view for 1 second) was also entirely inaccurate, since the slots typically render for about a second _before_ the ad is shown.



[PTOW-2]: https://pubai.atlassian.net/browse/PTOW-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ