### PR TITLE
PTOW-2 pubx.ai analytics adapter

### DIFF
--- a/modules/pubxaiAnalyticsAdapter.js
+++ b/modules/pubxaiAnalyticsAdapter.js
@@ -261,26 +261,25 @@ export const getDeviceType = () => {
  * @returns {string}
  */
 export const getBrowser = () => {
-  if (/Edg/.test(navigator.userAgent)) return 'Microsoft Edge';
+  if (/Edg/.test(navigator.userAgent)) return "Microsoft Edge";
   else if (
     /Chrome/.test(navigator.userAgent) &&
     /Google Inc/.test(navigator.vendor)
-  ) {
+  )
     return "Chrome";
-  } else if (navigator.userAgent.match("CriOS")) return "Chrome";
+  else if (navigator.userAgent.match("CriOS")) return "Chrome";
   else if (/Firefox/.test(navigator.userAgent)) return "Firefox";
-  else if (/Edg/.test(navigator.userAgent)) return "Microsoft Edge";
   else if (
     /Safari/.test(navigator.userAgent) &&
     /Apple Computer/.test(navigator.vendor)
-  ) {
+  )
     return "Safari";
-  } else if (
+  else if (
     /Trident/.test(navigator.userAgent) ||
     /MSIE/.test(navigator.userAgent)
-  ) {
+  )
     return "Internet Explorer";
-  } else return "Others";
+  else return "Others";
 };
 
 /**

--- a/modules/pubxaiAnalyticsAdapter.js
+++ b/modules/pubxaiAnalyticsAdapter.js
@@ -4,11 +4,11 @@ import {
   getWindowLocation,
   buildUrl,
   cyrb53Hash,
-} from '../src/utils.js';
-import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
-import adapterManager from '../src/adapterManager.js';
-import CONSTANTS from '../src/constants.js';
-import { getGlobal } from '../src/prebidGlobal.js';
+} from "../src/utils.js";
+import adapter from "../libraries/analyticsAdapter/AnalyticsAdapter.js";
+import adapterManager from "../src/adapterManager.js";
+import { EVENTS } from "../src/constants.js";
+import { getGlobal } from "../src/prebidGlobal.js";
 import {
   getGptSlotInfoForAdUnitCode,
   getGptSlotForAdUnitCode,
@@ -176,20 +176,20 @@ const extractBid = (bidResponse) => {
 const track = ({ eventType, args }) => {
   switch (eventType) {
     // handle invalid bids, and remove them from the adUnit cache
-    case CONSTANTS.EVENTS.BID_TIMEOUT:
+    case EVENTS.BID_TIMEOUT:
       args.map(extractBid).forEach((bid) => {
         bid.renderStatus = 3;
         auctionCache[bid.auctionId].bids.push(bid);
       });
       break;
     // handle valid bid responses and record them as part of an auction
-    case CONSTANTS.EVENTS.BID_RESPONSE:
+    case EVENTS.BID_RESPONSE:
       const bid = Object.assign(extractBid(args), { renderStatus: 2 });
       auctionCache[bid.auctionId].bids.push(bid);
       break;
     // capture extra information from the auction, and if there were no bids
     // (and so no chance of a win) send the auction
-    case CONSTANTS.EVENTS.AUCTION_END:
+    case EVENTS.AUCTION_END:
       Object.assign(
         auctionCache[args.auctionId].floorDetail,
         args.adUnits
@@ -210,7 +210,7 @@ const track = ({ eventType, args }) => {
       }
       break;
     // send the prebid winning bid back to pubx
-    case CONSTANTS.EVENTS.BID_WON:
+    case EVENTS.BID_WON:
       const winningBid = extractBid(args);
       const floorDetail = auctionCache[winningBid.auctionId].floorDetail;
       Object.assign(winningBid, {
@@ -265,21 +265,21 @@ export const getBrowser = () => {
   else if (
     /Chrome/.test(navigator.userAgent) &&
     /Google Inc/.test(navigator.vendor)
-  )
+  ) {
     return "Chrome";
-  else if (navigator.userAgent.match("CriOS")) return "Chrome";
+  } else if (navigator.userAgent.match("CriOS")) return "Chrome";
   else if (/Firefox/.test(navigator.userAgent)) return "Firefox";
   else if (
     /Safari/.test(navigator.userAgent) &&
     /Apple Computer/.test(navigator.vendor)
-  )
+  ) {
     return "Safari";
-  else if (
+  } else if (
     /Trident/.test(navigator.userAgent) ||
     /MSIE/.test(navigator.userAgent)
-  )
+  ) {
     return "Internet Explorer";
-  else return "Others";
+  } else return "Others";
 };
 
 /**

--- a/modules/pubxaiAnalyticsAdapter.js
+++ b/modules/pubxaiAnalyticsAdapter.js
@@ -181,9 +181,13 @@ const track = ({ eventType, args }) => {
     case CONSTANTS.EVENTS.AUCTION_END:
       Object.assign(
         auctionCache[args.auctionId].floorDetail,
-        deepAccess(args, 'adUnits.0.bids.0.floorData')
+        args.adUnits
+          .map((i) => i?.bids.length && i.bids[0]?.floorData)
+          .find((i) => i) || {}
       );
-      auctionCache[args.auctionId].pageDetail.adUnits = args.adUnitCodes;
+      auctionCache[args.auctionId].deviceDetail.cdep = args.bidderRequests
+        .map((bidRequest) => bidRequest.ortb2?.device?.ext?.cdep)
+        .find((i) => i);
       Object.assign(auctionCache[args.auctionId].auctionDetail, {
         adUnitCodes: args.adUnits.map((i) => i.code),
         timestamp: args.timestamp,

--- a/test/spec/modules/pubxaiAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubxaiAnalyticsAdapter_spec.js
@@ -111,6 +111,13 @@ describe('pubxai analytics adapter', () => {
                 bidderWinsCount: 0,
               },
             ],
+            ortb2: {
+              device: {
+                ext: {
+                  cdep: true,
+                },
+              },
+            },
             auctionStart: 1603865707180,
             timeout: 1000,
             refererInfo: {
@@ -168,6 +175,13 @@ describe('pubxai analytics adapter', () => {
             bidderWinsCount: 0,
           },
         ],
+        ortb2: {
+          device: {
+            ext: {
+              cdep: true,
+            },
+          },
+        },
         auctionStart: 1603865707180,
         timeout: 1000,
         refererInfo: {
@@ -319,6 +333,13 @@ describe('pubxai analytics adapter', () => {
                 bidderWinsCount: 0,
               },
             ],
+            ortb2: {
+              device: {
+                ext: {
+                  cdep: true,
+                },
+              },
+            },
             auctionStart: 1603865707180,
             timeout: 1000,
             refererInfo: {
@@ -484,16 +505,6 @@ describe('pubxai analytics adapter', () => {
           },
         ],
       },
-      // pageDetail: {
-      //   host: location.host,
-      //   path: location.pathname,
-      //   search: location.search,
-      // },
-      // pmcDetail: {
-      //   bidDensity: storage.getItem("pbx:dpbid"),
-      //   maxBid: storage.getItem("pbx:mxbid"),
-      //   auctionId: storage.getItem("pbx:aucid"),
-      // },
     };
 
     let expectedAfterBid = {
@@ -552,7 +563,6 @@ describe('pubxai analytics adapter', () => {
         host: location.host,
         path: location.pathname,
         search: location.search,
-        adUnits: ['/19968336/header-bid-tag-1'],
       },
       floorDetail: {
         fetchStatus: 'success',
@@ -567,9 +577,13 @@ describe('pubxai analytics adapter', () => {
         deviceType: getDeviceType(),
         deviceOS: getOS(),
         browser: getBrowser(),
+        cdep: true,
       },
       userDetail: {
         userIdTypes: [],
+      },
+      consentDetail: {
+        consentTypes: [],
       },
       pmacDetail: JSON.parse(storage.getItem('pbx:pmac')) || {},
       initOptions: {
@@ -642,7 +656,6 @@ describe('pubxai analytics adapter', () => {
         host: location.host,
         path: location.pathname,
         search: location.search,
-        adUnits: ['/19968336/header-bid-tag-1'],
       },
       floorDetail: {
         fetchStatus: 'success',
@@ -657,9 +670,13 @@ describe('pubxai analytics adapter', () => {
         deviceType: getDeviceType(),
         deviceOS: getOS(),
         browser: getBrowser(),
+        cdep: true,
       },
       userDetail: {
         userIdTypes: [],
+      },
+      consentDetail: {
+        consentTypes: [],
       },
       pmacDetail: JSON.parse(storage.getItem('pbx:pmac')) || {},
       initOptions: {


### PR DESCRIPTION
Ticket: [PTOW-2](https://pubai.atlassian.net/browse/PTOW-2)

Task: update the pubx analytics adapter, to make use of more modern approaches and to consume more data.

Implements:
- Using beacons to send data to pubx endpoints.
  - The beacon preserves the content type of the data.
- Deep copy of the data is sent to pubx, and is not modified throughout the auction (done). 
  - The data sent back is cloned before send. 
  - Each of the properties present in the auction is either not taken from the auction itself, or taken as a deep copy
- Sample the auction and winning bids together.
  - The sampling uses a hash of the auction id, so that wins and auctions are sampled together. 
  - The sampling is _not_ done on the page level, to avoid skewing sampling towards "repeat" auctions, which are less valuable. 
- verification of the rank of the auction on the page.
  - as auctions are held, their rank in time is preserved. 
  - This auction rank is not specific to an adslot, but global to the page.
  - I have observed consistent behaviour that an auction can have multiple winning bids, each independently rendered. In this case the auction rank is not incremented/repeated, as no auction is held to promote a new winning bid to render.
- Google object data (key value pairs)
  - The google ad server data is constructed before the bidwon event from prebid
  - i was unable to observe any occasion where GAM rendering did not trigger a prebid win event
  - the gam data is tied to an ad slot, and as mentioned above, single auctions were observed rendering many winning bids into the same slot, making tracking the specific GPT KVPs for a bid _impossible_. The KVPs associated to the winning bid are the KVPs available at the time of the winning bid event firing in prebid.
- PMAC data
  - as requested via slack, the PMAC data is loaded from session storage, and expected to be partitioned by auction id. 
  - no data manipulation was done on the pmac data from local storage
- user ids
  - captured from the prebid globals. The types of user ids _only_ are recorded, but the schema could be expanded to support more user information in future.
- Floor price in case of no bids
  - there is a wonderful variable in the priceFloors.js module, _floorDataForAuction, which contains _all_ information, derived or otherwise, regarding the price floor information of an auction, up to 3 seconds after the auction ends. Try as i might, i am unable to record the data from this meta variable.
  - i am pulling price data from the ad unit bids of the prebid auction. The "bid" property of an ad unit is declared by the publisher, and then augmented by the price floors module later in the auction lifecycle. In the event that no bids occur, the ad units will still exist, and the "bid" property of the ad unit, which defines the bidders that should provide responses, is also still defined.
- concurrency support
  - I observed several cases of multiple auctions running concurrently across the ad units of a page. Typically it seems that rather than bundle multiple ad units into one auction, each ad unit has a separate auction. We used to aggregate all bids for "an auction" under one list, and then send the array of bids back as part of the same auction. This meant that regularly, the bids attributed to a single auction were actually part of many auctions, and so the floor data we sent back was messed up (being derived from the first bid)

Not implemented:
- viewability
  - i attempted to use the gpt viewbility module, and because auctions can have multiple winning bids, but the gpt event can only track at the slot level, it was not possible to create a mapping between a bid and a "view event"
  - attempting to use the intersection observer didn't yield sensible results. I attempted to update the insersection observers data in realtime before the send to pubx, which didn't produce good/reliable/accurate viewability results, and attempting to leave the data to the initial data recorded by the observer was similarly inaccurate.
  - attempting to "construct" a viewable event (i.e 50% in view for 1 second) was also entirely inaccurate, since the slots typically render for about a second _before_ the ad is shown.



[PTOW-2]: https://pubai.atlassian.net/browse/PTOW-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

This PR had issues when merged, and as requested a new PR has been raised.