### PR TITLE
switching from sessionStorage to localStorage

### DIFF
--- a/modules/pubxaiAnalyticsAdapter.js
+++ b/modules/pubxaiAnalyticsAdapter.js
@@ -25,8 +25,7 @@ const pubxaiAnalyticsVersion = 'v2.0.0';
 const defaultHost = 'api.pbxai.com';
 const auctionPath = '/analytics/auction';
 const winningBidPath = '/analytics/bidwon';
-
-export const storage = getStorageManager({ moduleType: MODULE_TYPE_ANALYTICS, moduleName: adapterCode })
+const storage = getStorageManager({ moduleType: MODULE_TYPE_ANALYTICS, moduleName: adapterCode })
 
 /**
  * The sendCache is a global cache object which tracks the pending sends

--- a/modules/pubxaiAnalyticsAdapter.js
+++ b/modules/pubxaiAnalyticsAdapter.js
@@ -13,15 +13,20 @@ import {
   getGptSlotInfoForAdUnitCode,
   getGptSlotForAdUnitCode,
 } from '../libraries/gptUtils/gptUtils.js';
+import { getStorageManager } from '../src/storageManager.js';
+import { MODULE_TYPE_ANALYTICS } from '../src/activities/modules.js';
 
 let initOptions;
 
 const emptyUrl = '';
 const analyticsType = 'endpoint';
+const adapterCode = 'pubxai';
 const pubxaiAnalyticsVersion = 'v2.0.0';
 const defaultHost = 'api.pbxai.com';
 const auctionPath = '/analytics/auction';
 const winningBidPath = '/analytics/bidwon';
+
+export const storage = getStorageManager({ moduleType: MODULE_TYPE_ANALYTICS, moduleName: adapterCode })
 
 /**
  * The sendCache is a global cache object which tracks the pending sends
@@ -75,7 +80,7 @@ export const auctionCache = new Proxy(
           consentDetail: {
             consentTypes: Object.keys(getGlobal().getConsentMetadata?.() || {}),
           },
-          pmacDetail: JSON.parse(getStorage()?.getItem('pubx:pmac')) || {}, // {auction_1: {floor:0.23,maxBid:0.34,bidCount:3},auction_2:{floor:0.13,maxBid:0.14,bidCount:2}
+          pmacDetail: JSON.parse(storage.getDataFromLocalStorage('pubx:pmac')) || {}, // {auction_1: {floor:0.23,maxBid:0.34,bidCount:3},auction_2:{floor:0.13,maxBid:0.14,bidCount:2}
           initOptions: {
             ...initOptions,
             auctionId: name, // back-compat
@@ -119,18 +124,6 @@ const getAdServerDataForBid = (bid) => {
     );
   }
   return {}; // TODO: support more ad servers
-};
-
-/**
- * Access sessionStorage
- * @returns {Storage}
- */
-const getStorage = () => {
-  try {
-    return window.top['sessionStorage'];
-  } catch (e) {
-    return null;
-  }
 };
 
 /**
@@ -423,7 +416,7 @@ pubxaiAnalyticsAdapter.enableAnalytics = (config) => {
 
 adapterManager.registerAnalyticsAdapter({
   adapter: pubxaiAnalyticsAdapter,
-  code: 'pubxai',
+  code: adapterCode,
 });
 
 export default pubxaiAnalyticsAdapter;

--- a/test/spec/modules/pubxaiAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubxaiAnalyticsAdapter_spec.js
@@ -3,7 +3,6 @@ import pubxaiAnalyticsAdapter, {
   getOS,
   getBrowser,
   auctionCache,
-  storage,
 } from 'modules/pubxaiAnalyticsAdapter.js';
 import { expect } from 'chai';
 import adapterManager from 'src/adapterManager.js';
@@ -600,7 +599,7 @@ describe('pubxai analytics adapter', () => {
       consentDetail: {
         consentTypes: Object.keys(getGlobal().getConsentMetadata?.() || {}),
       },
-      pmacDetail: JSON.parse(storage.getDataFromLocalStorage('pubx:pmac')) || {},
+      pmacDetail: {},
       initOptions: {
         ...initOptions,
         auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
@@ -693,7 +692,7 @@ describe('pubxai analytics adapter', () => {
       consentDetail: {
         consentTypes: Object.keys(getGlobal().getConsentMetadata?.() || {}),
       },
-      pmacDetail: JSON.parse(storage.getDataFromLocalStorage('pubx:pmac')) || {},
+      pmacDetail: {},
       initOptions: {
         ...initOptions,
         auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
@@ -765,7 +764,7 @@ describe('pubxai analytics adapter', () => {
         expect(Object.fromEntries(parsedUrl.searchParams)).to.deep.equal({
           auctionTimestamp: '1616654312804',
           pubxaiAnalyticsVersion: 'v2.0.0',
-          prebidVersion: getGlobal()?.version,
+          prebidVersion: String(getGlobal().version),
         });
         expect(expectedData.type).to.equal('text/json');
         expect(JSON.parse(await readBlobSafariCompat(expectedData))).to.deep.equal([
@@ -808,7 +807,7 @@ describe('pubxai analytics adapter', () => {
       expect(Object.fromEntries(parsedUrl.searchParams)).to.deep.equal({
         auctionTimestamp: '1616654312804',
         pubxaiAnalyticsVersion: 'v2.0.0',
-        prebidVersion: getGlobal()?.version,
+        prebidVersion: String(getGlobal().version),
       });
 
       // Step 9: check that the data sent in the request is correct
@@ -933,7 +932,7 @@ describe('pubxai analytics adapter', () => {
         expect(Object.fromEntries(parsedUrl.searchParams)).to.deep.equal({
           auctionTimestamp: '1616654312804',
           pubxaiAnalyticsVersion: 'v2.0.0',
-          prebidVersion: getGlobal()?.version,
+          prebidVersion: String(getGlobal().version),
         });
         expect(expectedData.type).to.equal('text/json');
         expect(JSON.parse(await readBlobSafariCompat(expectedData))).to.deep.equal([
@@ -1049,7 +1048,7 @@ describe('pubxai analytics adapter', () => {
         expect(Object.fromEntries(parsedUrl.searchParams)).to.deep.equal({
           auctionTimestamp: '1616654312804',
           pubxaiAnalyticsVersion: 'v2.0.0',
-          prebidVersion: getGlobal()?.version,
+          prebidVersion: String(getGlobal().version),
         });
         expect(expectedData.type).to.equal('text/json');
         expect(JSON.parse(await readBlobSafariCompat(expectedData))).to.deep.equal([

--- a/test/spec/modules/pubxaiAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubxaiAnalyticsAdapter_spec.js
@@ -3,6 +3,7 @@ import pubxaiAnalyticsAdapter, {
   getOS,
   getBrowser,
   auctionCache,
+  storage,
 } from 'modules/pubxaiAnalyticsAdapter.js';
 import { expect } from 'chai';
 import adapterManager from 'src/adapterManager.js';
@@ -42,7 +43,6 @@ describe('pubxai analytics adapter', () => {
     let originalVS;
 
     let location = utils.getWindowLocation();
-    let storage = window.top['sessionStorage'];
 
     const replaceProperty = (obj, params) => {
       let strObj = JSON.stringify(obj);
@@ -600,7 +600,7 @@ describe('pubxai analytics adapter', () => {
       consentDetail: {
         consentTypes: Object.keys(getGlobal().getConsentMetadata?.() || {}),
       },
-      pmacDetail: JSON.parse(storage.getItem('pbx:pmac')) || {},
+      pmacDetail: JSON.parse(storage.getDataFromLocalStorage('pubx:pmac')) || {},
       initOptions: {
         ...initOptions,
         auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
@@ -693,7 +693,7 @@ describe('pubxai analytics adapter', () => {
       consentDetail: {
         consentTypes: Object.keys(getGlobal().getConsentMetadata?.() || {}),
       },
-      pmacDetail: JSON.parse(storage.getItem('pbx:pmac')) || {},
+      pmacDetail: JSON.parse(storage.getDataFromLocalStorage('pubx:pmac')) || {},
       initOptions: {
         ...initOptions,
         auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',


### PR DESCRIPTION
The prebid.js pull request for the analytics adapter: 
https://github.com/prebid/Prebid.js/pull/11425
Has review actions, with very specific objections to our use of sessionStorage. 

This PR switches to localStorage, and uses Prebid.js source methods for connecting to localStorage.


To save money, i've only tested our tests via browserstack; running the rest takes quite some time:
<img width="589" alt="Screenshot 2024-06-11 at 14 12 17" src="https://github.com/Pubx-ai/Prebid.js/assets/157742646/96de90ed-efea-4ba9-9faa-628a53a2d0b9">
