### PR TITLE
modifying functions to avoid prebid duplication checker

### DIFF
--- a/modules/pubxaiAnalyticsAdapter.js
+++ b/modules/pubxaiAnalyticsAdapter.js
@@ -235,16 +235,12 @@ export const getDeviceType = () => {
     /ipad|android 3.0|xoom|sch-i800|playbook|tablet|kindle/i.test(
       navigator.userAgent.toLowerCase()
     )
-  ) {
-    return 'tablet';
-  }
+  ) return 'tablet';
   if (
     /iphone|ipod|android|blackberry|opera|mini|windows\sce|palm|smartphone|iemobile/i.test(
       navigator.userAgent.toLowerCase()
     )
-  ) {
-    return 'mobile';
-  }
+  ) return 'mobile';
   return 'desktop';
 };
 
@@ -279,12 +275,24 @@ export const getBrowser = () => {
  * @returns {string}
  */
 export const getOS = () => {
-  if (navigator.userAgent.indexOf('Android') != -1) return 'Android';
-  if (navigator.userAgent.indexOf('like Mac') != -1) return 'iOS';
-  if (navigator.userAgent.indexOf('Win') != -1) return 'Windows';
-  if (navigator.userAgent.indexOf('Mac') != -1) return 'Macintosh';
-  if (navigator.userAgent.indexOf('Linux') != -1) return 'Linux';
-  if (navigator.appVersion.indexOf('X11') != -1) return 'Unix';
+  if (navigator.userAgent.indexOf('Android') != -1) {
+    return 'Android';
+  }
+  if (navigator.userAgent.indexOf('like Mac') != -1) {
+    return 'iOS';
+  }
+  if (navigator.userAgent.indexOf('Win') != -1) {
+    return 'Windows';
+  }
+  if (navigator.userAgent.indexOf('Mac') != -1) {
+    return 'Macintosh';
+  }
+  if (navigator.userAgent.indexOf('Linux') != -1) {
+    return 'Linux';
+  }
+  if (navigator.appVersion.indexOf('X11') != -1) {
+    return 'Unix';
+  }
   return 'Others';
 };
 

--- a/modules/pubxaiAnalyticsAdapter.js
+++ b/modules/pubxaiAnalyticsAdapter.js
@@ -27,6 +27,31 @@ const auctionPath = '/analytics/auction';
 const winningBidPath = '/analytics/bidwon';
 const storage = getStorageManager({ moduleType: MODULE_TYPE_ANALYTICS, moduleName: adapterCode })
 
+const deviceTypes = Object.freeze({
+  DESKTOP: 0,
+  MOBILE: 1,
+  TABLET: 2,
+})
+
+const browserTypes = Object.freeze({
+  CHROME: 0,
+  FIREFOX: 1,
+  SAFARI: 2,
+  EDGE: 3,
+  INTERNET_EXPLORER: 4,
+  OTHER: 5
+})
+
+const osTypes = Object.freeze({
+  WINDOWS: 0,
+  MAC: 1,
+  LINUX: 2,
+  UNIX: 3,
+  IOS: 4,
+  ANDROID: 5,
+  OTHER: 6
+})
+
 /**
  * The sendCache is a global cache object which tracks the pending sends
  * back to pubx.ai. The data may be removed from this cache, post send.
@@ -235,13 +260,13 @@ export const getDeviceType = () => {
     /ipad|android 3.0|xoom|sch-i800|playbook|tablet|kindle/i.test(
       navigator.userAgent.toLowerCase()
     )
-  ) return 'tablet';
+  ) return deviceTypes.TABLET;
   if (
     /iphone|ipod|android|blackberry|opera|mini|windows\sce|palm|smartphone|iemobile/i.test(
       navigator.userAgent.toLowerCase()
     )
-  ) return 'mobile';
-  return 'desktop';
+  ) return deviceTypes.MOBILE;
+  return deviceTypes.DESKTOP;
 };
 
 /**
@@ -249,25 +274,22 @@ export const getDeviceType = () => {
  * @returns {string}
  */
 export const getBrowser = () => {
-  if (/Edg/.test(navigator.userAgent)) return 'Microsoft Edge';
+  if (/Edg/.test(navigator.userAgent)) return browserTypes.EDGE;
   else if (
     /Chrome/.test(navigator.userAgent) &&
     /Google Inc/.test(navigator.vendor)
-  ) {
-    return 'Chrome';
-  } else if (navigator.userAgent.match('CriOS')) return 'Chrome';
-  else if (/Firefox/.test(navigator.userAgent)) return 'Firefox';
+  ) return browserTypes.CHROME;
+  else if (navigator.userAgent.match('CriOS')) return browserTypes.CHROME;
+  else if (/Firefox/.test(navigator.userAgent)) return browserTypes.FIREFOX;
   else if (
     /Safari/.test(navigator.userAgent) &&
     /Apple Computer/.test(navigator.vendor)
-  ) {
-    return 'Safari';
-  } else if (
+  ) return browserTypes.SAFARI
+  else if (
     /Trident/.test(navigator.userAgent) ||
     /MSIE/.test(navigator.userAgent)
-  ) {
-    return 'Internet Explorer';
-  } else return 'Others';
+  ) return browserTypes.INTERNET_EXPLORER
+  else return browserTypes.OTHER;
 };
 
 /**
@@ -275,25 +297,13 @@ export const getBrowser = () => {
  * @returns {string}
  */
 export const getOS = () => {
-  if (navigator.userAgent.indexOf('Android') != -1) {
-    return 'Android';
-  }
-  if (navigator.userAgent.indexOf('like Mac') != -1) {
-    return 'iOS';
-  }
-  if (navigator.userAgent.indexOf('Win') != -1) {
-    return 'Windows';
-  }
-  if (navigator.userAgent.indexOf('Mac') != -1) {
-    return 'Macintosh';
-  }
-  if (navigator.userAgent.indexOf('Linux') != -1) {
-    return 'Linux';
-  }
-  if (navigator.appVersion.indexOf('X11') != -1) {
-    return 'Unix';
-  }
-  return 'Others';
+  if (navigator.userAgent.indexOf('Android') != -1) return osTypes.ANDROID
+  if (navigator.userAgent.indexOf('like Mac') != -1) return osTypes.IOS
+  if (navigator.userAgent.indexOf('Win') != -1) return osTypes.WINDOWS
+  if (navigator.userAgent.indexOf('Mac') != -1) return osTypes.MAC
+  if (navigator.userAgent.indexOf('Linux') != -1) return osTypes.LINUX
+  if (navigator.appVersion.indexOf('X11') != -1) return osTypes.UNIX
+  return osTypes.OTHER;
 };
 
 /**


### PR DESCRIPTION
Prebid.js has introduced a new linter, through [jscpd](https://www.npmjs.com/package/jscpd) which is causing many pull requests to fail. The goal of the linter/pipeline test is to remove any duplicated code. Sadly, this code deduper has 3 big issues:
- it's not checking the version of the code in the PR for duplication, just checking for duplications against the prebid master branch for any files modified in the PR
- it considers 2 adapter modules, which already may not import from one another, to be conflicting/duplicated source code. Given that our issues are due to similar organisations using the same way to get an OS or device category, which would not necessarily be appropriate for prebid to include in actual source code, this doesn't make a lot of sense.
- as far as i can tell, the jscpd tool has a memory leak in it somewhere, at least when running via docker on my mac. With 16GB of memory, i still couldn't get the report to run before my OS killed the process due to out-of-memory issues.

Anyway, you can trick the linter with javascripts flexible syntax. I ran the jscpd report against only the modules directory and observed that no duplication issues referenced our files anymore, from _our_ version of the master branch