### PR TITLE
'fixing' tests

### DIFF
--- a/test/spec/modules/pubxaiAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubxaiAnalyticsAdapter_spec.js
@@ -22,6 +22,7 @@ const readBlobSafariCompat = (blob) => {
 
 describe('pubxai analytics adapter', () => {
   beforeEach(() => {
+    getGlobal().refreshUserIds()
     sinon.stub(events, 'getEvents').returns([]);
   });
 
@@ -591,7 +592,7 @@ describe('pubxai analytics adapter', () => {
         cdep: true,
       },
       userDetail: {
-        userIdTypes: [],
+        userIdTypes: Object.keys(getGlobal().getUserIds?.() || {}),
       },
       consentDetail: {
         consentTypes: Object.keys(getGlobal().getConsentMetadata?.() || {}),
@@ -685,7 +686,7 @@ describe('pubxai analytics adapter', () => {
         cdep: true,
       },
       userDetail: {
-        userIdTypes: [],
+        userIdTypes: Object.keys(getGlobal().getUserIds?.() || {}),
       },
       consentDetail: {
         consentTypes: Object.keys(getGlobal().getConsentMetadata?.() || {}),


### PR DESCRIPTION
Some new tests are fixing the user ids available as part of all other tests that run. When you run our test alone, they passed absolutely fine. When you allow webpack to build and run the entire test suite, they fail.

I couldn't find which set of tests were modifying the available user ids, so i've elected to reset all of the user ids at the beginning of each test.