### PR TITLE
send BidRejected Events to capture floored bids

### DIFF
--- a/modules/pubxaiAnalyticsAdapter.js
+++ b/modules/pubxaiAnalyticsAdapter.js
@@ -157,14 +157,18 @@ const track = ({ eventType, args }) => {
     // handle invalid bids, and remove them from the adUnit cache
     case EVENTS.BID_TIMEOUT:
       args.map(extractBid).forEach((bid) => {
-        bid.renderStatus = 3;
+        bid.bidType = 3;
         auctionCache[bid.auctionId].bids.push(bid);
       });
       break;
     // handle valid bid responses and record them as part of an auction
     case EVENTS.BID_RESPONSE:
-      const bid = Object.assign(extractBid(args), { renderStatus: 2 });
+      const bid = Object.assign(extractBid(args), { bidType: 2 });
       auctionCache[bid.auctionId].bids.push(bid);
+      break;
+    case EVENTS.BID_REJECTED:
+      const rejectedBid = Object.assign(extractBid(args), { bidType: 1 });
+      auctionCache[rejectedBid.auctionId].bids.push(rejectedBid);
       break;
     // capture extra information from the auction, and if there were no bids
     // (and so no chance of a win) send the auction
@@ -183,7 +187,7 @@ const track = ({ eventType, args }) => {
         timestamp: args.timestamp,
       });
       if (
-        auctionCache[args.auctionId].bids.every((bid) => bid.renderStatus === 3)
+        auctionCache[args.auctionId].bids.every((bid) => bid.bidType === 3)
       ) {
         prepareSend(args.auctionId);
       }
@@ -201,7 +205,7 @@ const track = ({ eventType, args }) => {
         isFloorSkipped: floorDetail?.skipped || false,
         isWinningBid: true,
         renderedSize: args.size,
-        renderStatus: 4,
+        bidType: 4,
       });
       winningBid.adServerData = getAdServerDataForBid(winningBid);
       auctionCache[winningBid.auctionId].winningBid = winningBid;

--- a/modules/pubxaiAnalyticsAdapter.js
+++ b/modules/pubxaiAnalyticsAdapter.js
@@ -20,6 +20,8 @@ const analyticsType = 'endpoint';
 const adapterCode = 'pubxai';
 const pubxaiAnalyticsVersion = 'v2.0.0';
 const defaultHost = 'api.pbxai.com';
+const auctionPath = '/analytics/auction';
+const winningBidPath = '/analytics/bidwon';
 const storage = getStorageManager({ moduleType: MODULE_TYPE_ANALYTICS, moduleName: adapterCode })
 
 /**
@@ -234,10 +236,9 @@ const prepareSend = (auctionId) => {
   if (!shouldFireEventRequest(auctionId, initOptions.samplingRate)) {
     return;
   }
-  const pubxID = initOptions.pubxId;
   [
     {
-      path: `/analytics/${pubxID}/bidwon`,
+      path: winningBidPath,
       requiredKeys: [
         'winningBid',
         'pageDetail',
@@ -252,7 +253,7 @@ const prepareSend = (auctionId) => {
       eventType: 'win',
     },
     {
-      path: `/analytics/${pubxID}/auction`,
+      path: auctionPath,
       requiredKeys: [
         'bids',
         'pageDetail',
@@ -286,6 +287,7 @@ const prepareSend = (auctionId) => {
         auctionTimestamp: auctionData.auctionDetail.timestamp,
         pubxaiAnalyticsVersion: pubxaiAnalyticsVersion,
         prebidVersion: '$prebid.version$',
+        pubxId: initOptions.pubxId,
       },
     });
     sendCache[pubxaiAnalyticsRequestUrl].push(data);

--- a/modules/pubxaiAnalyticsAdapter.js
+++ b/modules/pubxaiAnalyticsAdapter.js
@@ -20,8 +20,6 @@ const analyticsType = 'endpoint';
 const adapterCode = 'pubxai';
 const pubxaiAnalyticsVersion = 'v2.0.0';
 const defaultHost = 'api.pbxai.com';
-const auctionPath = '/analytics/auction';
-const winningBidPath = '/analytics/bidwon';
 const storage = getStorageManager({ moduleType: MODULE_TYPE_ANALYTICS, moduleName: adapterCode })
 
 /**
@@ -236,9 +234,10 @@ const prepareSend = (auctionId) => {
   if (!shouldFireEventRequest(auctionId, initOptions.samplingRate)) {
     return;
   }
+  const pubxID = initOptions.pubxId;
   [
     {
-      path: winningBidPath,
+      path: `/analytics/${pubxID}/bidwon`,
       requiredKeys: [
         'winningBid',
         'pageDetail',
@@ -253,7 +252,7 @@ const prepareSend = (auctionId) => {
       eventType: 'win',
     },
     {
-      path: auctionPath,
+      path: `/analytics/${pubxID}/auction`,
       requiredKeys: [
         'bids',
         'pageDetail',

--- a/test/spec/modules/pubxaiAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubxaiAnalyticsAdapter_spec.js
@@ -31,7 +31,7 @@ describe('pubxai analytics adapter', () => {
   });
 
   describe('track', () => {
-    const pubxId = '6c415fc0-8b0e-4cf5-be73-01526a4db625'
+    const pubxId = '6c415fc0-8b0e-4cf5-be73-01526a4db625';
     let initOptions = {
       samplingRate: '1',
       pubxId: pubxId,
@@ -759,12 +759,13 @@ describe('pubxai analytics adapter', () => {
         const [expectedUrl, expectedData] = arg;
         const parsedUrl = new URL(expectedUrl);
         expect(parsedUrl.pathname).to.equal(
-          [`/analytics/${pubxId}/bidwon`, `/analytics/${pubxId}/auction`][index]
+          ['/analytics/bidwon', '/analytics/auction'][index]
         );
         expect(Object.fromEntries(parsedUrl.searchParams)).to.deep.equal({
           auctionTimestamp: '1616654312804',
           pubxaiAnalyticsVersion: 'v2.0.0',
           prebidVersion: '$prebid.version$',
+          pubxId: pubxId,
         });
         expect(expectedData.type).to.equal('text/json');
         expect(JSON.parse(await readBlobSafariCompat(expectedData))).to.deep.equal([
@@ -801,13 +802,14 @@ describe('pubxai analytics adapter', () => {
       // Step 7: check the pathname of the calls is correct (sent only to the auction endpoint)
       const [expectedUrl, expectedData] = navigator.sendBeacon.args[0];
       const parsedUrl = new URL(expectedUrl);
-      expect(parsedUrl.pathname).to.equal(`/analytics/${pubxId}/auction`);
+      expect(parsedUrl.pathname).to.equal('/analytics/auction');
 
       // Step 8: check that the meta information in the call is correct
       expect(Object.fromEntries(parsedUrl.searchParams)).to.deep.equal({
         auctionTimestamp: '1616654312804',
         pubxaiAnalyticsVersion: 'v2.0.0',
         prebidVersion: '$prebid.version$',
+        pubxId: pubxId,
       });
 
       // Step 9: check that the data sent in the request is correct
@@ -927,12 +929,13 @@ describe('pubxai analytics adapter', () => {
         const parsedUrl = new URL(expectedUrl);
         const auctionIdMapFn = index < 2 ? (i, _) => i : replaceProperty;
         expect(parsedUrl.pathname).to.equal(
-          [`/analytics/${pubxId}/bidwon`, `/analytics/${pubxId}/auction`][index % 2]
+          ['/analytics/bidwon', '/analytics/auction'][index % 2]
         );
         expect(Object.fromEntries(parsedUrl.searchParams)).to.deep.equal({
           auctionTimestamp: '1616654312804',
           pubxaiAnalyticsVersion: 'v2.0.0',
           prebidVersion: '$prebid.version$',
+          pubxId: pubxId,
         });
         expect(expectedData.type).to.equal('text/json');
         expect(JSON.parse(await readBlobSafariCompat(expectedData))).to.deep.equal([
@@ -1043,12 +1046,13 @@ describe('pubxai analytics adapter', () => {
         const [expectedUrl, expectedData] = arg;
         const parsedUrl = new URL(expectedUrl);
         expect(parsedUrl.pathname).to.equal(
-          [`/analytics/${pubxId}/bidwon`, `/analytics/${pubxId}/auction`][index]
+          ['/analytics/bidwon', '/analytics/auction'][index]
         );
         expect(Object.fromEntries(parsedUrl.searchParams)).to.deep.equal({
           auctionTimestamp: '1616654312804',
           pubxaiAnalyticsVersion: 'v2.0.0',
           prebidVersion: '$prebid.version$',
+          pubxId: pubxId,
         });
         expect(expectedData.type).to.equal('text/json');
         expect(JSON.parse(await readBlobSafariCompat(expectedData))).to.deep.equal([

--- a/test/spec/modules/pubxaiAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubxaiAnalyticsAdapter_spec.js
@@ -31,9 +31,10 @@ describe('pubxai analytics adapter', () => {
   });
 
   describe('track', () => {
+    const pubxId = '6c415fc0-8b0e-4cf5-be73-01526a4db625'
     let initOptions = {
       samplingRate: '1',
-      pubxId: '6c415fc0-8b0e-4cf5-be73-01526a4db625',
+      pubxId: pubxId,
     };
 
     let originalVS;
@@ -148,7 +149,7 @@ describe('pubxai analytics adapter', () => {
         timeout: 1000,
         config: {
           samplingRate: '1',
-          pubxId: '6c415fc0-8b0e-4cf5-be73-01526a4db625',
+          pubxId: pubxId,
         },
       },
       bidRequested: {
@@ -529,7 +530,7 @@ describe('pubxai analytics adapter', () => {
             null,
           auctionId: 'bc3806e4-873e-453c-8ae5-204f35e923b4',
           sizes: '300x250',
-          renderStatus: 2,
+          bidType: 2,
           requestTimestamp: 1616654312804,
           creativeId: 96846035,
           currency: 'USD',
@@ -651,7 +652,7 @@ describe('pubxai analytics adapter', () => {
         placementId: 13144370,
         renderedSize: '300x250',
         sizes: '300x250',
-        renderStatus: 4,
+        bidType: 4,
         responseTimestamp: 1616654313071,
         requestTimestamp: 1616654312804,
         status: 'rendered',
@@ -758,7 +759,7 @@ describe('pubxai analytics adapter', () => {
         const [expectedUrl, expectedData] = arg;
         const parsedUrl = new URL(expectedUrl);
         expect(parsedUrl.pathname).to.equal(
-          ['/analytics/bidwon', '/analytics/auction'][index]
+          [`/analytics/${pubxId}/bidwon`, `/analytics/${pubxId}/auction`][index]
         );
         expect(Object.fromEntries(parsedUrl.searchParams)).to.deep.equal({
           auctionTimestamp: '1616654312804',
@@ -800,7 +801,7 @@ describe('pubxai analytics adapter', () => {
       // Step 7: check the pathname of the calls is correct (sent only to the auction endpoint)
       const [expectedUrl, expectedData] = navigator.sendBeacon.args[0];
       const parsedUrl = new URL(expectedUrl);
-      expect(parsedUrl.pathname).to.equal('/analytics/auction');
+      expect(parsedUrl.pathname).to.equal(`/analytics/${pubxId}/auction`);
 
       // Step 8: check that the meta information in the call is correct
       expect(Object.fromEntries(parsedUrl.searchParams)).to.deep.equal({
@@ -926,7 +927,7 @@ describe('pubxai analytics adapter', () => {
         const parsedUrl = new URL(expectedUrl);
         const auctionIdMapFn = index < 2 ? (i, _) => i : replaceProperty;
         expect(parsedUrl.pathname).to.equal(
-          ['/analytics/bidwon', '/analytics/auction'][index % 2]
+          [`/analytics/${pubxId}/bidwon`, `/analytics/${pubxId}/auction`][index % 2]
         );
         expect(Object.fromEntries(parsedUrl.searchParams)).to.deep.equal({
           auctionTimestamp: '1616654312804',
@@ -1042,7 +1043,7 @@ describe('pubxai analytics adapter', () => {
         const [expectedUrl, expectedData] = arg;
         const parsedUrl = new URL(expectedUrl);
         expect(parsedUrl.pathname).to.equal(
-          ['/analytics/bidwon', '/analytics/auction'][index]
+          [`/analytics/${pubxId}/bidwon`, `/analytics/${pubxId}/auction`][index]
         );
         expect(Object.fromEntries(parsedUrl.searchParams)).to.deep.equal({
           auctionTimestamp: '1616654312804',


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
