### PR TITLE
Pub 2941 fixing missing logging of invalid bids

### DIFF
--- a/modules/pubxaiAnalyticsAdapter.js
+++ b/modules/pubxaiAnalyticsAdapter.js
@@ -188,7 +188,7 @@ const track = ({ eventType, args }) => {
         timestamp: args.timestamp,
       });
       if (
-        auctionCache[args.auctionId].bids.every((bid) => bid.bidType === 3)
+        auctionCache[args.auctionId].bids.every((bid) => [1, 3].includes(bid.bidType))
       ) {
         prepareSend(args.auctionId);
       }

--- a/test/spec/modules/pubxaiAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubxaiAnalyticsAdapter_spec.js
@@ -22,8 +22,8 @@ const readBlobSafariCompat = (blob) => {
 
 describe('pubxai analytics adapter', () => {
   beforeEach(() => {
-    getGlobal().refreshUserIds()
     sinon.stub(events, 'getEvents').returns([]);
+    getGlobal().refreshUserIds?.()
   });
 
   afterEach(() => {
@@ -776,15 +776,15 @@ describe('pubxai analytics adapter', () => {
       }
     });
 
-    it('auction with no bids', async () => {
+    it('auction data with only rejected bids', async () => {
       // Step 1: Send auction init event
       events.emit(EVENTS.AUCTION_INIT, prebidEvent['auctionInit']);
 
       // Step 2: Send bid requested event
       events.emit(EVENTS.BID_REQUESTED, prebidEvent['bidRequested']);
 
-      // Step 3: Send bid time out event
-      events.emit(EVENTS.BID_TIMEOUT, prebidEvent['bidTimeout']);
+      // Step 3: Send bid rejected (afaict the only expected reason would be a bid being too low)
+      events.emit(EVENTS.BID_REJECTED, prebidEvent['bidResponse']);
 
       // Simulate "navigate away" behaviour
       document.dispatchEvent(new Event('visibilitychange'));
@@ -815,6 +815,105 @@ describe('pubxai analytics adapter', () => {
       });
 
       // Step 9: check that the data sent in the request is correct
+      expect(expectedData.type).to.equal('text/json');
+      expect(JSON.parse(await readBlobSafariCompat(expectedData))).to.deep.equal([
+        {
+          ...expectedAfterBid,
+          bids: [{
+            ...expectedAfterBid.bids[0],
+            bidType: 1
+          }]
+        }
+      ]);
+    });
+
+    it('auction data with only timed out bids', async () => {
+      // Step 1: Send auction init event
+      events.emit(EVENTS.AUCTION_INIT, prebidEvent['auctionInit']);
+
+      // Step 2: Send bid requested event
+      events.emit(EVENTS.BID_REQUESTED, prebidEvent['bidRequested']);
+
+      // Step 3: Send bid rejected (afaict the only expected reason would be a bid being too low)
+      events.emit(EVENTS.BID_TIMEOUT, [prebidEvent['bidResponse']]);
+
+      // Simulate "navigate away" behaviour
+      document.dispatchEvent(new Event('visibilitychange'));
+
+      // Step 4: check the number of calls made to pubx.ai
+      expect(navigator.sendBeacon.callCount).to.equal(0);
+
+      // Step 5: Send auction end event
+      events.emit(EVENTS.AUCTION_END, prebidEvent['auctionEnd']);
+
+      // Simulate end of session
+      document.dispatchEvent(new Event('visibilitychange'));
+
+      // Step 6: check the number of calls made to pubx.ai
+      expect(navigator.sendBeacon.callCount).to.equal(1);
+
+      // Step 7: check the pathname of the calls is correct (sent only to the auction endpoint)
+      const [expectedUrl, expectedData] = navigator.sendBeacon.args[0];
+      const parsedUrl = new URL(expectedUrl);
+      expect(parsedUrl.pathname).to.equal('/analytics/auction');
+
+      // Step 8: check that the meta information in the call is correct
+      expect(Object.fromEntries(parsedUrl.searchParams)).to.deep.equal({
+        auctionTimestamp: '1616654312804',
+        pubxaiAnalyticsVersion: 'v2.1.0',
+        prebidVersion: '$prebid.version$',
+        pubxId: pubxId,
+      });
+
+      // Step 9: check that the data sent in the request is correct
+      expect(expectedData.type).to.equal('text/json');
+      expect(JSON.parse(await readBlobSafariCompat(expectedData))).to.deep.equal([
+        {
+          ...expectedAfterBid,
+          bids: [{
+            ...expectedAfterBid.bids[0],
+            bidType: 3
+          }]
+        }
+      ]);
+    });
+
+    it('auction with no bids', async () => {
+      // Step 1: Send auction init event
+      events.emit(EVENTS.AUCTION_INIT, prebidEvent['auctionInit']);
+
+      // Step 2: Send bid requested event
+      events.emit(EVENTS.BID_REQUESTED, prebidEvent['bidRequested']);
+
+      // Simulate "navigate away" behaviour
+      document.dispatchEvent(new Event('visibilitychange'));
+
+      // Step 3: check the number of calls made to pubx.ai
+      expect(navigator.sendBeacon.callCount).to.equal(0);
+
+      // Step 4: Send auction end event
+      events.emit(EVENTS.AUCTION_END, prebidEvent['auctionEnd']);
+
+      // Simulate end of session
+      document.dispatchEvent(new Event('visibilitychange'));
+
+      // Step 5: check the number of calls made to pubx.ai
+      expect(navigator.sendBeacon.callCount).to.equal(1);
+
+      // Step 6: check the pathname of the calls is correct (sent only to the auction endpoint)
+      const [expectedUrl, expectedData] = navigator.sendBeacon.args[0];
+      const parsedUrl = new URL(expectedUrl);
+      expect(parsedUrl.pathname).to.equal('/analytics/auction');
+
+      // Step 7: check that the meta information in the call is correct
+      expect(Object.fromEntries(parsedUrl.searchParams)).to.deep.equal({
+        auctionTimestamp: '1616654312804',
+        pubxaiAnalyticsVersion: 'v2.1.0',
+        prebidVersion: '$prebid.version$',
+        pubxId: pubxId,
+      });
+
+      // Step 8: check that the data sent in the request is correct
       expect(expectedData.type).to.equal('text/json');
       expect(JSON.parse(await readBlobSafariCompat(expectedData))).to.deep.equal([
         {


### PR DESCRIPTION
Ticket: [PUB-2941](https://pubai.atlassian.net/browse/PUB-2941)

This ticket addresses an issue in which an auction containing only invalid bids is not recorded.

Invalid bids are mapped to bidtype 1. Timed-out bids are mapped to bidtype 3. If any auction contains only bidtypes 1 or 3, it is now sent to pubx (assuming the relevant downsampling permits this).

There was a query as to whether or not auctions. with no bids at all were recorded. using the javascript array.prototype.every function on an empty array returns true, so this condition is satisfied. An additional test already verified this in prebid, but the test was _quite_ obscure, so i tried to tidy it up a little.

Additional tests were added to confirm that auctions with timed out bids or invalid bids (as far as i can tell this only occurs due to pricing issues) are also recorded.

[PUB-2941]: https://pubai.atlassian.net/browse/PUB-2941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ