### PR TITLE
remove endpoint as optional

### DIFF
--- a/modules/pubxaiRtdProvider.md
+++ b/modules/pubxaiRtdProvider.md
@@ -37,7 +37,7 @@ pbjs.setConfig({
 			waitForIt: true,
 			params: {
 				pubxId: `<publisher_id>`,
-				endpoint: `<publisher_endpoint>`, // (optional)
+				endpoint: `<publisher_endpoint>`,
 				floorMin: `<floorMin>`, // (optional)
 				enforcement: `<enforcement>`, // (optional)
 				data: `<defaultConfig>` // (optional)
@@ -57,7 +57,7 @@ pbjs.setConfig({
 | waitForIt          | Boolean | Should be `true` if an `auctionDelay` is defined (optional)    | `false`                    |
 | params             | Object  |                                                                |                            |
 | params.pubxId      | String  | Publisher ID                                                   |                            |
-| params.endpoint    | String  | URL to retrieve floor data (optional)                          | `https://floor.pbxai.com/` |
+| params.endpoint    | String  | URL to retrieve floor data                     		|			     |
 | params.floorMin    | Number  | Minimum CPM floor (optional)                                   | `None`                     |
 | params.enforcement | Object  | Enforcement behavior within the Price Floors Module (optional) | `None`                     |
 | params.data        | Object  | Default floor data provided by pubX.ai (optional)              | `None`                     |


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
